### PR TITLE
Add GRPC Alpine variant SDK image

### DIFF
--- a/backend/app_sdk/Dockerfile_alpine_grpc
+++ b/backend/app_sdk/Dockerfile_alpine_grpc
@@ -1,0 +1,42 @@
+FROM python:3.10.0-alpine as base
+
+FROM base as builder
+RUN apk --no-cache add --update \
+        alpine-sdk \
+        build-base  \
+        g++ \
+        gcc \
+        libffi \
+        libffi-dev \
+        libstdc++ \
+        linux-headers \
+        musl-dev \
+        openssl-dev \
+        tzdata \
+        coreutils
+
+RUN pip install --upgrade pip && \
+    pip install --prefix="/install" --no-cache-dir grpcio grpcio-tools && \
+    apk del --purge \
+    g++ \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    libstdc++ \
+    build-base \
+    linux-headers
+
+RUN mkdir -p /install
+WORKDIR /install
+
+FROM base
+
+#--no-cache
+RUN apk update && apk add --update tzdata libmagic alpine-sdk libffi libffi-dev musl-dev openssl-dev coreutils
+
+COPY --from=builder /install /usr/local
+COPY requirements.txt /requirements.txt
+RUN pip3 install -r /requirements.txt
+
+COPY __init__.py /app/walkoff_app_sdk/__init__.py
+COPY app_base.py /app/walkoff_app_sdk/app_base.py


### PR DESCRIPTION
Alpine can take quite a long time when building the wheel for the GRPC package(s). This PR combines the package into the Alpine image to speed up the building of app images that use GRPC.