### PR TITLE
chore: Fixed repo url to point to Shuffle org

### DIFF
--- a/.github/install-guide.md
+++ b/.github/install-guide.md
@@ -11,7 +11,7 @@ The Docker setup is done with docker-compose
 1. Make sure you have [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
 2. Download Shuffle
 ```bash
-git clone https://github.com/frikky/Shuffle
+git clone https://github.com/Shuffle/Shuffle
 cd Shuffle
 ```
 


### PR DESCRIPTION
Guess the repo moved to the org. Event though it still works like this, it seems more consistent to use its current url.