### PR TITLE
Fix Dockerbuild GitHub actions. 

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -2,7 +2,11 @@ name: dockerbuild
 
 on:
   push:
-    branches: [main] 
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'  # Ignore changes to markdown files
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Solves #1242 

I added the paths-ignore option under the on section to specify that changes to markdown files (**.md) should be ignored, preventing the action from running for these files.


