### PR TITLE
Update nginx.conf v1.3 to allow UI view of workflow runs (Issue #1256)

### DIFF
--- a/frontend/confd/templates/nginx.conf
+++ b/frontend/confd/templates/nginx.conf
@@ -122,7 +122,8 @@ http {
 		}
 
 		# Get the hostname from environment here?
-		location /api/v1 {
+		# location /api/v1 {
+		location ~ /api/v(1|2) {
 			proxy_pass http://{{ getenv "BACKEND_HOSTNAME" "shuffle-backend" }}:5001;
 			proxy_buffering off;
 			proxy_http_version 1.1;


### PR DESCRIPTION
This nginx config patch addresses Issue #1256 wherein the workflow run history in the UI is visible when access is by http, but not https. The patch duplicates work done by @frikky for the http server block (allowing proxy of api calls for version 1 or 2) to the https server block. While the patch resolves the issue, folks more familiar with the implication should QC before accepting.