### PR TITLE
fixed overflow in conditions

### DIFF
--- a/frontend/src/views/AngularWorkflow.jsx
+++ b/frontend/src/views/AngularWorkflow.jsx
@@ -9767,6 +9767,8 @@ const AngularWorkflow = (defaultprops) => {
                   marginTop: "15px",
                   marginLeft: "10px",
                   overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",  
                   maxWidth: 72,
                 }}
               >
@@ -9786,7 +9788,7 @@ const AngularWorkflow = (defaultprops) => {
                   flex: 1,
                   textAlign: "center",
                   marginTop: "15px",
-                  overflow: "hidden",
+                  overflow: "hidden",  
                   maxWidth: 72,
                 }}
                 onClick={() => { }}
@@ -9810,6 +9812,8 @@ const AngularWorkflow = (defaultprops) => {
                   marginBottom: "auto",
                   marginLeft: "10px",
                   overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
                   maxWidth: 72,
                 }}
               >


### PR DESCRIPTION
### description
 this pr fixes the overflow of text in the conditons

### changes made 
- added textOverflow: "ellipsis"  this adds "..."  to indicate that there is more content than is currently visible.
- added whiteSpace is set to "nowrap", it explicitly instructs the browser not to allow text to wrap to the next line, It forces the 
   text to stay on a single line, even if it exceeds the container's width.

### before : 

![Screenshot (36)](https://github.com/Shuffle/Shuffle/assets/141043716/5fa4b368-92a7-42df-80c1-2b6e1d7a6f13)

### After : 

![Screenshot (37)](https://github.com/Shuffle/Shuffle/assets/141043716/70e9c8a9-2206-4263-9414-9892a361a097)

