### PR TITLE
Fix for default org creation error for first user. 

### DIFF
--- a/backend/go-app/main.go
+++ b/backend/go-app/main.go
@@ -580,7 +580,7 @@ func handleRegister(resp http.ResponseWriter, request *http.Request) {
 				Name:      orgSetupName,
 				Id:        orgId,
 				Org:       orgSetupName,
-				Users:     []shuffle.User{},
+				Users:     []shuffle.User{user},
 				Roles:     []string{"admin", "user"},
 				CloudSync: false,
 			}
@@ -614,6 +614,8 @@ func handleRegister(resp http.ResponseWriter, request *http.Request) {
 					Id:   newOrg.Id,
 					Name: newOrg.Name,
 				}
+
+                user.ActiveOrg = currentOrg
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the problem that I was facing that is creating not creating a org when I register my first admin user. I noticed the  `handleRegister` does not set the Active Org for the user and does not add the first user to the org. Which I think is the reason behind the error. I tested it with my change in code and it worked and again did the same without the changes and I get the error where no organisation is created for the user.