### PR TITLE
fixes after trying to spin up shuffle on kubernetes

### DIFF
--- a/functions/kubernetes/all-in-one.yaml
+++ b/functions/kubernetes/all-in-one.yaml
@@ -22,6 +22,7 @@ data:
   FRONTEND_PORT_HTTPS: "3443"
   HTTP_PROXY: ""
   HTTPS_PROXY: ""
+  KUBERNETES_NAMESPACE: shuffle
   ORBORUS_CONTAINER_NAME: "\t\t\t\t"
   ORG_ID: Shuffle
   OUTER_HOSTNAME: shuffle-backend
@@ -764,6 +765,11 @@ spec:
               value: "1.40"
             - name: ENVIRONMENT_NAME
               value: Shuffle
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  key: KUBERNETES_NAMESPACE
+                  name: env
             - name: ORG_ID
               value: Shuffle
             - name: SHUFFLE_APP_SDK_VERSION

--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -756,7 +756,6 @@ func deployWorker(image string, identifier string, env []string, executionReques
 			},
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
-				DNSPolicy:     "Default",
 				// NodeSelector: map[string]string{
 				// 	"node": "master",
 				// },

--- a/functions/onprem/orborus/orborus.yaml
+++ b/functions/onprem/orborus/orborus.yaml
@@ -56,7 +56,6 @@ spec:
         io.kompose.network/shuffle: "true"
         io.kompose.service: orborus
     spec:
-      dnsPolicy: "Default"
       containers:
         - env:
             - name: BASE_URL

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -455,7 +455,6 @@ func deployApp(cli *dockerclient.Client, image string, identifier string, env []
 			},
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never", // As a crash is not useful in this context 
-				DNSPolicy:     "Default",
 				// NodeName:      "worker1"
 				Containers: []corev1.Container{
 					{


### PR DESCRIPTION
Hi! I did a deploy of Shuffle using current main in a Kubernetes cluster using instructions at https://github.com/Shuffle/Shuffle/tree/main/functions/kubernetes and ran into some challenges with the configuration there.

First issue was that Orborus was logging that it couldn't read pods in the default namespace. After looking at Orborus' source, it appears that the `all-in-one.yaml` was missing the KUBERNETES_NAMESPACE env var for this deployment. Once I added that Orborus worked just fine.

The second issue was that the worker pods couldn't connect to the backend pod:

```
2024/06/03 19:44:44 [ERROR] Failed getting stream results: Post "http://shuffle-backend:5001/api/v1/streams/results": dial tcp: lookup shuffle-backend on 10.4.0.2:53: no such host
2024/06/03 19:44:44 [ERROR] Failed request: Post "http://shuffle-backend:5001/api/v1/streams/results": dial tcp: lookup shuffle-backend on 10.4.0.2:53: no such host
```

It turns out that this was because those pods were being created with the `dnsPolicy` value of `Default`. This means that those pods receive DNS configuration from the underlying node and can't do DNS lookups against the cluster's internal nameserver.

In case it's not known, that's not the "default" in Kubernetes and it doesn't allow the in-cluster name resolution to work properly, so that connection to the backend will never work successfully. See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

I can't find in the history why this value was set to `Default`, but if it does need to be set that way for backwards compatibility or other reasons, it could be made into a configuration option. However, I would argue that it should be `ClusterFirst` by default and if a cluster administrator needs the pod to resolve names that can't be resolved by the cluster's internal DNS server, then it should be on the administrator to configure that at the cluster layer instead. Since `ClusterFirst` is the default anyway, the argument can simply be dropped.