### PR TITLE
Added the feature of window swapping

### DIFF
--- a/frontend/src/components/ParsedAction.jsx
+++ b/frontend/src/components/ParsedAction.jsx
@@ -166,7 +166,7 @@ const ParsedAction = (props) => {
 	setExpansionModalOpen,
 
 	listCache,
-	
+	setActiveDialog,
 	authGroups,
 	apps,
 	setEditorData,
@@ -3079,7 +3079,7 @@ const ParsedAction = (props) => {
 									event.preventDefault()
 									setFieldCount(count)
 									setExpansionModalOpen(true)
-
+									setActiveDialog("codeeditor")
 									//setcodedata(data.value)
 									var parsedvalue = data.value
 									if (parsedvalue === undefined || parsedvalue === null) {

--- a/frontend/src/components/ShuffleCodeEditor1.jsx
+++ b/frontend/src/components/ShuffleCodeEditor1.jsx
@@ -105,7 +105,8 @@ const CodeEditor = (props) => {
 		selectedAction ,
 		workflowExecutions,
 		getParents,
-
+		activeDialog,
+		setActiveDialog,
 		fieldname,
 		contentLoading,
 	} = props
@@ -958,10 +959,10 @@ const CodeEditor = (props) => {
 
 	return (
 		<Dialog
-			aria-labelledby="draggable-code-modal"
-			disableBackdropClick={true}
+			aria-labelledby="draggable-dialog-title"
+			// disableBackdropClick={true}
 			disableEnforceFocus={true}
-      		//style={{ pointerEvents: "none" }}
+      		style={{ pointerEvents: "none", zIndex: activeDialog === "codeeditor" ? 1200 : 1100}}
 			hideBackdrop={true}
 			open={expansionModalOpen}
 			onClose={() => {
@@ -976,8 +977,10 @@ const CodeEditor = (props) => {
 			}}
 			PaperComponent={PaperComponent}
 			PaperProps={{
+				onClick: () => setActiveDialog("codeeditor"),
 				style: {
-					zIndex: 12501,
+					// zIndex: 12501,
+					pointerEvents: "auto",
 					color: "white",
 					minWidth: isMobile ? "100%" : isFileEditor ? 650 : "80%",
 					maxWidth: isMobile ? "100%" : isFileEditor ? 650 : 1100,
@@ -1525,6 +1528,7 @@ const CodeEditor = (props) => {
 							whiteSpace: "pre-wrap",
 							wordWrap: "break-word",
 							backgroundColor: "rgba(40,40,40,1)",
+							zIndex: activeDialog === "codeeditor" ? 1200 : 1100,
 						}}
 						onLoad={(editor) => {
 							highlight_variables(localcodedata)
@@ -1577,6 +1581,7 @@ const CodeEditor = (props) => {
 										paddingLeft: 10, 
 										paddingTop: 0, 
 										display: "flex", 
+										cursor: "move"
 									}}
 								>
 									<div>
@@ -1629,6 +1634,7 @@ const CodeEditor = (props) => {
 												overflow: "auto",
 												minWidth: 450, 
 												maxWidth: "100%", 
+												zIndex: activeDialog === "codeeditor" ? 1200 : 1100,
 											}}
 											collapsed={false}
 											enableClipboard={(copy) => {
@@ -1661,6 +1667,7 @@ const CodeEditor = (props) => {
 												minHeight: 450, 
 												overflow: "auto", 
                                                 wordWrap: "anywhere",
+												zIndex: activeDialog === "codeeditor" ? 1200 : 1100,
 											}}
 										>
 											{expOutput}

--- a/frontend/src/views/AngularWorkflow.jsx
+++ b/frontend/src/views/AngularWorkflow.jsx
@@ -483,7 +483,7 @@ const AngularWorkflow = (defaultprops) => {
   const [selectedTriggerIndex, setSelectedTriggerIndex] = React.useState({});
   const [selectedEdge, setSelectedEdge] = React.useState({});
   const [selectedEdgeIndex, setSelectedEdgeIndex] = React.useState({});
-
+  const [activeDialog, setActiveDialog] = React.useState("");
   const [visited, setVisited] = React.useState([]);
   const [allRevisions, setAllRevisions] = useState([])
 
@@ -19170,6 +19170,7 @@ const releaseToConnectLabel = "Release to Connect"
 							  //console.log("Click data: ", data)
 							  //data.action.label = ""
 							  setSelectedResult(data);
+                setActiveDialog("result")
 							  setCodeModalOpen(true);
 						  } else {
 							  toast("Please wait until the workflow is loaded and try again")
@@ -19606,10 +19607,11 @@ const releaseToConnectLabel = "Release to Connect"
 		PaperComponent={PaperComponent}
 		aria-labelledby="draggable-dialog-title"
         disableEnforceFocus={true}
-        style={{ pointerEvents: "none" }}
+        style={{ pointerEvents: "none", zIndex : activeDialog === "result" ? 1200 : 1100 }}
         hideBackdrop={true}
         open={codeModalOpen}
         PaperProps={{
+          onClick : () => setActiveDialog("result"),
           style: {
             pointerEvents: "auto",
             color: "white",
@@ -19618,7 +19620,7 @@ const releaseToConnectLabel = "Release to Connect"
             maxHeight: 550,
             overflowY: "auto",
             overflowX: "hidden",
-            zIndex: 10012,
+            // zIndex: 10012,
 						border: theme.palette.defaultBorder,
           },
         }}
@@ -20054,7 +20056,7 @@ const releaseToConnectLabel = "Release to Connect"
         lastSaved={lastSaved}
 		aiSubmit={aiSubmit}
   		listCache={listCache}
-
+        setActiveDialog={setActiveDialog}
 		apps={apps}
 		expansionModalOpen={codeEditorModalOpen}
 		setExpansionModalOpen={setCodeEditorModalOpen}
@@ -21935,6 +21937,8 @@ const releaseToConnectLabel = "Release to Connect"
 				fieldname={editorData.field_id}
 
 				changeActionParameterCodeMirror={changeActionParameterCodeMirror}
+        activeDialog={activeDialog}
+        setActiveDialog={setActiveDialog}
 	  		/>
 		: null}
 


### PR DESCRIPTION
## Issue fixed : 
- You can now easily switch between the result of any node and the code editor directly!
  - Preview : 

  [swapping.webm](https://github.com/Shuffle/Shuffle/assets/99136041/70e2c023-ae3b-454b-9138-67fd242a6823)

- Fixed this one :
![image](https://github.com/Shuffle/Shuffle/assets/99136041/06dfca7d-c2ea-4a75-952c-6027de8d0e26)
Found that **jumping nature of cursor of code editor** at the time of execution of the workflow to the input field was coming from the main branch itself :)

Issue : #1408 