### PR TITLE
[Feature] Add Endpoint for Hotloading Specific Applications

### DIFF
--- a/.github/install-guide.md
+++ b/.github/install-guide.md
@@ -104,13 +104,25 @@ yarn start
 ## Backend - Golang
 http://localhost:5001 - REST API - requires [>=go1.13](https://golang.org/dl/)
 ```bash
-export SHUFFLE_OPENSEARCH_URL="https://localhost:9200"
+# Find 'shuffle-opensearch' docker ip
+ip_address=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' shuffle-opensearch)
+# validate if ip was found
+if [ -z "$ip_address" ]; then
+    echo "Error: Unable to obtain the IP of the container 'shuffle-opensearch'"
+    exit 1
+fi
+export SHUFFLE_OPENSEARCH_URL="https://${ip_address}:9200"
 export SHUFFLE_ELASTIC=true
 export SHUFFLE_OPENSEARCH_USERNAME=admin
-export SHUFFLE_OPENSEARCH_PASSWORD=admin
+# Since the latest updates to OpenSearch, the password complexity directive has been activated, and this value has not yet been changed to the current .env default.
+export SHUFFLE_OPENSEARCH_PASSWORD="StrongShufflePassword321!"
 export SHUFFLE_OPENSEARCH_SKIPSSL_VERIFY=true
+# Variables needed to test the changes
+export SHUFFLE_APP_HOTLOAD_FOLDER=/opt/Shuffle/shuffle-apps
+export SHUFFLE_APP_HOTLOAD_LOCATION=/opt/Shuffle/shuffle-apps
 cd backend/go-app
 go run main.go walkoff.go docker.go
+
 ```
 **WINDOWS USERS:** Follow [this guide](https://www.wikihow.com/Create-an-Environment-Variable-in-Windows-10) to add environment variables in your machine.
 

--- a/backend/go-app/main.go
+++ b/backend/go-app/main.go
@@ -256,7 +256,6 @@ type Hook struct {
 	Environment string       `json:"environment" datastore:"environment"`
 }
 
-
 func GetUsersHandler(w http.ResponseWriter, r *http.Request) {
 	data := map[string]interface{}{
 		"id": "12345",
@@ -511,7 +510,6 @@ func createNewUser(username, password, role, apikey string, org shuffle.OrgMini)
 		}
 	}
 
-
 	return nil
 }
 
@@ -615,7 +613,7 @@ func handleRegister(resp http.ResponseWriter, request *http.Request) {
 					Name: newOrg.Name,
 				}
 
-                user.ActiveOrg = currentOrg
+				user.ActiveOrg = currentOrg
 			}
 		}
 	}
@@ -884,7 +882,6 @@ func handleInfo(resp http.ResponseWriter, request *http.Request) {
 		log.Printf("[DEBUG] Failed to get org during getinfo: %s", err)
 	}
 
-
 	//if err == nil {
 	if len(org.Id) > 0 {
 		userInfo.ActiveOrg = shuffle.OrgMini{
@@ -994,7 +991,7 @@ func handleInfo(resp http.ResponseWriter, request *http.Request) {
 		Tutorials:    tutorialsFinished,
 
 		Priorities: orgPriorities,
-		Licensed: 		  licensed,
+		Licensed:   licensed,
 	}
 
 	returnData, err := json.Marshal(returnValue)
@@ -1014,7 +1011,6 @@ type passwordReset struct {
 	Password2 string `json:"newpassword2"`
 	Reference string `json:"reference"`
 }
-
 
 func checkAdminLogin(resp http.ResponseWriter, request *http.Request) {
 	cors := shuffle.HandleCors(resp, request)
@@ -1999,7 +1995,7 @@ func handlePipelineCallback(resp http.ResponseWriter, request *http.Request) {
 	location := strings.Split(request.URL.String(), "/")
 
 	var pipelineId string
-	
+
 	if location[1] == "api" {
 		if len(location) <= 4 {
 			log.Printf("[INFO] Couldn't handle location. Too short in pipeline: %d", len(location))
@@ -3208,7 +3204,6 @@ func buildSwaggerApp(resp http.ResponseWriter, body []byte, user shuffle.User, s
 		}
 	}
 
-
 	log.Printf("[DEBUG] Successfully built app %s (%s)", api.Name, api.ID)
 	if len(user.Id) > 0 {
 		resp.WriteHeader(200)
@@ -3248,8 +3243,6 @@ func verifySwagger(resp http.ResponseWriter, request *http.Request) {
 
 	buildSwaggerApp(resp, body, user, false)
 }
-
-
 
 // Hotloads new apps from a folder
 func handleAppHotload(ctx context.Context, location string, forceUpdate bool) error {
@@ -3597,11 +3590,10 @@ func remoteOrgJobController(org shuffle.Org, body []byte) error {
 	return nil
 }
 
-
 func remoteOrgJobHandler(org shuffle.Org, interval int) error {
 
 	// Check if it's 1 in 10 (10% chance random)
-	backupJob := shuffle.BackupJob{} 
+	backupJob := shuffle.BackupJob{}
 
 	// Check if workflow backup is active
 	// Check if app backup is active
@@ -3646,7 +3638,6 @@ func remoteOrgJobHandler(org shuffle.Org, interval int) error {
 		log.Printf("[ERROR] Failed marshalling backup job: %s", err)
 		backupJobData = []byte{}
 	}
-
 
 	syncUrl := fmt.Sprintf("%s/api/v1/cloud/sync", syncUrl)
 	client := shuffle.GetExternalClient(syncUrl)
@@ -3853,7 +3844,7 @@ func runInitEs(ctx context.Context) {
 			}
 
 			// FIXME: Add a randomized timer to avoid all schedules running at the same time
-			// Many are at 5 minutes / 1 hour. The point is to spread these out 
+			// Many are at 5 minutes / 1 hour. The point is to spread these out
 			// a bit instead of all of them starting at the exact same time
 
 			//log.Printf("Schedule: %#v", schedule)
@@ -4205,17 +4196,16 @@ func runInitEs(ctx context.Context) {
 		log.Printf("[INFO] Skipping download of extra API samples as %d were found", len(workflowapps))
 	}
 
-	
 	if os.Getenv("SHUFFLE_HEALTHCHECK_DISABLED") != "true" {
-		healthcheckInterval := 30 
+		healthcheckInterval := 30
 		log.Printf("[INFO] Starting healthcheck job every %d minute. Stats available on /api/v1/health/stats. Disable with SHUFFLE_HEALTHCHECK_DISABLED=true", healthcheckInterval)
 		job := func() {
-			// Prepare a fake http.responsewriter 
+			// Prepare a fake http.responsewriter
 			resp := httptest.NewRecorder()
 
 			request := http.Request{}
 			// Add the "force=true" query to the fake request
-			request.URL, err  = url.Parse("/api/v1/health/stats?force=true")
+			request.URL, err = url.Parse("/api/v1/health/stats?force=true")
 			if err != nil {
 				log.Printf("[ERROR] Failed to parse test url for healthstats: %s", err)
 			}
@@ -4233,7 +4223,6 @@ func runInitEs(ctx context.Context) {
 
 	log.Printf("[INFO] Finished INIT (ES)")
 }
-
 
 func handleVerifyCloudsync(orgId string) (shuffle.SyncFeatures, error) {
 	ctx := context.Background()
@@ -4813,8 +4802,6 @@ func makeWorkflowPublic(resp http.ResponseWriter, request *http.Request) {
 	resp.Write([]byte(fmt.Sprintf(`{"success": true}`)))
 }
 
-
-
 func handleAppZipUpload(resp http.ResponseWriter, request *http.Request) {
 	cors := shuffle.HandleCors(resp, request)
 	if cors {
@@ -4873,8 +4860,6 @@ func handleAppZipUpload(resp http.ResponseWriter, request *http.Request) {
 	resp.Write([]byte("OK"))
 }
 
-
-
 func initHandlers() {
 	var err error
 	ctx := context.Background()
@@ -4906,7 +4891,7 @@ func initHandlers() {
 		go runInitEs(ctx)
 	} else {
 		//go shuffle.runInit(ctx)
-		log.Printf("[ERROR] Opensearch is the only viable option. Please set SHUFFLE_ELASTIC=true") 
+		log.Printf("[ERROR] Opensearch is the only viable option. Please set SHUFFLE_ELASTIC=true")
 		os.Exit(1)
 	}
 
@@ -4977,6 +4962,7 @@ func initHandlers() {
 	r.HandleFunc("/api/v1/apps/{appId}", shuffle.DeleteWorkflowApp).Methods("DELETE", "OPTIONS")
 	r.HandleFunc("/api/v1/apps/{appId}/config", shuffle.GetWorkflowAppConfig).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/apps/run_hotload", handleAppHotloadRequest).Methods("GET", "OPTIONS")
+	r.HandleFunc("/api/v1/apps/{appName}/run_hotload", handleSingleAppHotloadRequest).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/apps/get_existing", LoadSpecificApps).Methods("POST", "OPTIONS")
 	r.HandleFunc("/api/v1/apps/download_remote", LoadSpecificApps).Methods("POST", "OPTIONS")
 	r.HandleFunc("/api/v1/apps/validate", validateAppInput).Methods("POST", "OPTIONS")
@@ -5055,7 +5041,7 @@ func initHandlers() {
 	r.HandleFunc("/api/v1/triggers/gmail/register", shuffle.HandleNewGmailRegister).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/triggers/gmail/getFolders", shuffle.HandleGetGmailFolders).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/triggers/pipeline", shuffle.HandleNewPipelineRegister).Methods("POST", "OPTIONS")
-    //r.HandleFunc("/api/v1/triggers/pipeline/save", shuffle.HandleSavePipelineInfo).Methods("PUT", "OPTIONS")
+	//r.HandleFunc("/api/v1/triggers/pipeline/save", shuffle.HandleSavePipelineInfo).Methods("PUT", "OPTIONS")
 	r.HandleFunc("/api/v1/pipelines/{key}", handlePipelineCallback).Methods("POST", "GET", "PATCH", "PUT", "DELETE", "OPTIONS")
 	r.HandleFunc("/api/v1/triggers", shuffle.HandleGetTriggers).Methods("GET", "OPTIONS")
 	//r.HandleFunc("/api/v1/triggers/gmail/routing", handleGmailRouting).Methods("POST", "OPTIONS")
@@ -5082,7 +5068,7 @@ func initHandlers() {
 
 	r.HandleFunc("/api/v1/orgs/{orgId}", shuffle.HandleDeleteOrg).Methods("DELETE", "OPTIONS")
 	r.HandleFunc("/api/v1/orgs/{orgId}/suborgs", shuffle.HandleGetSubOrgs).Methods("GET", "OPTIONS")
-	
+
 	// This is a new API that validates if a key has been seen before.
 	// Not sure what the best course of action is for it.
 	r.HandleFunc("/api/v1/environments/{key}/stop", shuffle.HandleStopExecutions).Methods("GET", "POST", "OPTIONS")
@@ -5103,7 +5089,6 @@ func initHandlers() {
 	r.HandleFunc("/api/v1/orgs/{orgId}/datastore", shuffle.HandleListCacheKeys).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/orgs/{orgId}/datastore", shuffle.HandleSetCacheKey).Methods("POST", "OPTIONS")
 	r.HandleFunc("/api/v1/orgs/{orgId}/datastore/{cache_key}", shuffle.HandleDeleteCacheKey).Methods("DELETE", "OPTIONS")
-
 
 	// Docker orborus specific - downloads an image
 	r.HandleFunc("/api/v1/get_docker_image", getDockerImage).Methods("POST", "OPTIONS")

--- a/backend/go-app/run.sh
+++ b/backend/go-app/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Find 'shuffle-opensearch' docker ip
+ip_address=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' shuffle-opensearch)
+# validate if ip was found
+if [ -z "$ip_address" ]; then
+    echo "Error: Unable to obtain the IP of the container 'shuffle-opensearch'"
+    exit 1
+fi
+export SHUFFLE_OPENSEARCH_URL="https://${ip_address}:9200"
+export SHUFFLE_ELASTIC=true
+export SHUFFLE_OPENSEARCH_USERNAME=admin
+# Since the latest updates to OpenSearch, the password complexity directive has been activated, and this value has not yet been changed to the current .env default.
+export SHUFFLE_OPENSEARCH_PASSWORD="StrongShufflePassword321!"
+export SHUFFLE_OPENSEARCH_SKIPSSL_VERIFY=true
+# Variables needed to test the changes
+export SHUFFLE_APP_HOTLOAD_FOLDER=/opt/Shuffle/shuffle-apps
+export SHUFFLE_APP_HOTLOAD_LOCATION=/opt/Shuffle/shuffle-apps
+#cd backend/go-app
+go run main.go walkoff.go docker.go

--- a/backend/go-app/tmp
+++ b/backend/go-app/tmp
@@ -1,0 +1,81 @@
+
+func handleSingleAppHotloadRequest(resp http.ResponseWriter, request *http.Request) {
+
+	log.Printf("--- ### CUSTOM MESSAGE LUIS")
+
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	ctx := context.Background()
+	cacheKey := fmt.Sprintf("workflowapps-sorted-1000")
+	shuffle.DeleteCache(ctx, cacheKey)
+	cacheKey = fmt.Sprintf("workflowapps-sorted-500")
+	shuffle.DeleteCache(ctx, cacheKey)
+	cacheKey = fmt.Sprintf("workflowapps-sorted-0")
+	shuffle.DeleteCache(ctx, cacheKey)
+
+	// Just need to be logged in
+	// FIXME - should have some permissions?
+	user, err := shuffle.HandleApiAuthentication(resp, request)
+	if err != nil {
+		log.Printf("Api authentication failed in app hotload: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	if user.Role != "admin" {
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "Must be admin to hotload apps"}`))
+		return
+	}
+
+	location := os.Getenv("SHUFFLE_APP_HOTLOAD_FOLDER")
+	if len(location) == 0 {
+		resp.WriteHeader(500)
+		resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "SHUFFLE_APP_HOTLOAD_FOLDER not specified in .env"}`)))
+		return
+	}
+	// DESDE AQUI
+	requestUrlFields := strings.Split(request.URL.String(), "/")
+
+	var appName string
+	if requestUrlFields[1] == "api" {
+		if len(requestUrlFields) <= 4 {
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false}`))
+			return
+		}
+
+		appName = requestUrlFields[4]
+		if strings.Contains(appName, "?") {
+			appName = strings.Split(appName, "?")[0]
+		}
+	}
+
+	var directory = location + "/" + appName
+	log.Printf("[DEBUG] directory: %s", directory)
+
+	log.Printf("[INFO] Starting hotloading from %s single app %s", directory, appName)
+
+	// hasta aqui
+	err = handleAppHotload(ctx, location, true, "")
+	if err != nil {
+		log.Printf("[WARNING] Failed app hotload: %s", err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(fmt.Sprintf(`{"success": false, "reason": "%s"}`, err)))
+		return
+	}
+
+	cacheKey = fmt.Sprintf("workflowapps-sorted-100")
+	shuffle.DeleteCache(ctx, cacheKey)
+	cacheKey = fmt.Sprintf("workflowapps-sorted-500")
+	shuffle.DeleteCache(ctx, cacheKey)
+	cacheKey = fmt.Sprintf("workflowapps-sorted-1000")
+	shuffle.DeleteCache(ctx, cacheKey)
+
+	resp.WriteHeader(200)
+	resp.Write([]byte(fmt.Sprintf(`{"success": true}`)))
+}


### PR DESCRIPTION
### Description
This pull request introduces a new endpoint to the backend API that allows hotloading a specific application. Instead of hotloading or refreshing all applications in the apps directory, the new endpoint targets a specific application using the appName.

**New Endpoint**:
`GET apps/{appName}/run_hotload`

**Related Issue and Comment**:
Refer to my comment on this issue: [https://github.com/Shuffle/Shuffle/issues/1450#issuecomment-2214513175](https://github.com/Shuffle/Shuffle/issues/1450#issuecomment-2214513175).

**Additional Changes in `install-guide.md`**:
- Added environment HOTLOAD variables.
- Fixed old password value.
- Hostname change to Docker IP inspection

Sry for the indentation fixes.
