### PR TITLE
Fixed the param value issue in Trigger: Webhook & Scheduler

### DIFF
--- a/frontend/src/views/AngularWorkflow.jsx
+++ b/frontend/src/views/AngularWorkflow.jsx
@@ -14823,6 +14823,7 @@ const releaseToConnectLabel = "Release to Connect"
         setSelectedTrigger(trigger);
         setWorkflow(workflow);
         saveWorkflow(workflow);
+        setSelectedTrigger({})
    
       })
       .catch((error) => {


### PR DESCRIPTION
Here is the preview of the Issue to make it easy to understand:

- Explaination : So Whenever we delete the Webhook we call the deleteWebhook method but it is taking some time so before it's completion we are setting selectedTrigger({}) to empty and after the completion it again sets the trigger to Webhook with stopped status but we have already removed the node so after that if we open any other trigger it will set the values of Webhook in param.

- I had 2 solutions one was to make the things async and all and the other one was just a one-liner and good to go so I used that one.
Preview: 

[triggerIssue.webm](https://github.com/user-attachments/assets/4940cea5-2cb8-47c5-8993-a16c7f70dad8)
