### PR TITLE
Fixed the app crash Issue

### DIFF
--- a/frontend/src/components/ParsedAction.jsx
+++ b/frontend/src/components/ParsedAction.jsx
@@ -2696,7 +2696,7 @@ const ParsedAction = (props) => {
             // selectedAction.selectedAuthentication = e.target.value
             // selectedAction.authentication_id = e.target.value.id
             if (
-              !selectedAction.auth_not_required &&
+            //   !selectedAction.auth_not_required &&
               selectedAction.selectedAuthentication !== undefined &&
               selectedAction.selectedAuthentication.fields !== undefined &&
               selectedAction.selectedAuthentication.fields[data.name] !==


### PR DESCRIPTION
We are trying to access `selectedAction.auth_not_required` to hide the authentication fields. However, as shown in the video, I logged the `selectedAction` object, and there is no property called `auth_not_required`.

Here is the preview of both the before and after:

Before : 

[Issuee.webm](https://github.com/user-attachments/assets/13bf97d0-f2b1-4697-8bc2-346d51a5694e)


After: 

[solution.webm](https://github.com/user-attachments/assets/b2a3fa5d-7094-4d29-8f74-13576c895785)



