### PR TITLE
[fix]: url-encode and url-decode properly

### DIFF
--- a/backend/app_sdk/app_base.py
+++ b/backend/app_sdk/app_base.py
@@ -298,6 +298,17 @@ def url_encode(base):
 
     return quote(base)
 
+@shuffle_filters.register
+def url_decode(base):
+    """url-decode a string"""
+    try:
+        from urllib import unquote_plus
+    except ImportError:
+        from urllib.parse import unquote_plus
+
+    return unquote_plus(base)
+
+
 ###
 ###
 ###

--- a/backend/app_sdk/app_base.py
+++ b/backend/app_sdk/app_base.py
@@ -288,6 +288,16 @@ def split(base, sep):
         return base.split(sep)
 
 
+@shuffle_filters.register
+def url_encode(base):
+    """url-encode a string"""
+    try:
+        from urllib import quote
+    except ImportError:
+        from urllib.parse import quote
+
+    return quote(base)
+
 ###
 ###
 ###


### PR DESCRIPTION
we just need to change the encode part as the liquid library decode the %20 by default but there encoding function works on '+' which is the reason they were not working properly.

snippet code from there side (from the library)
```python
@standard_filter_manager.register
def url_decode(base):
    """Url-decode a string"""
    try:
        from urllib import unquote
    except ImportError:
        from urllib.parse import unquote
    return unquote(base)
```

as we can we see they use unquote but there encode uses 

```python
@standard_filter_manager.register
def url_encode(base):
    """Url-encode a string"""
    try:
        from urllib import urlencode
    except ImportError:
        from urllib.parse import urlencode
    return urlencode({"": base})[1:]
```

which just encode the url with '+'.

So I just overwrite the encode to use quote so it matches with unquote. But the question become if we are not controlling the encoding and getting it from somewhere else how do we handle that?