### PR TITLE
Improve app builder

### DIFF
--- a/backend/go-app/docker.go
+++ b/backend/go-app/docker.go
@@ -349,7 +349,7 @@ func deleteJob(client *kubernetes.Clientset, jobName, namespace string) error {
 	})
 }
 
-func buildImage(tags []string, dockerfileFolder string) error {
+func buildImage(tags []string, dockerfileLocation string) error {
 
 	isKubernetes := false
 	if os.Getenv("IS_KUBERNETES") == "true" {
@@ -369,8 +369,7 @@ func buildImage(tags []string, dockerfileFolder string) error {
 
 		log.Printf("[INFO] registry name: %s", registryName)
 
-		contextDir := strings.Replace(dockerfileFolder, "Dockerfile", "", -1)
-		contextDir = "/app/" + contextDir
+		contextDir := filepath.Join("/app/", filepath.Dir(dockerfileLocation))
 		log.Print("contextDir: ", contextDir)
 
 		client, err := getK8sClient()
@@ -406,7 +405,7 @@ func buildImage(tags []string, dockerfileFolder string) error {
 								Image: "gcr.io/kaniko-project/executor:latest",
 								Args: []string{
 									"--verbosity=debug",
-									"--dockerfile=" + dockerFile,
+									"--dockerfile=Dockerfile",
 									"--context=dir://" + contextDir,
 									"--skip-tls-verify",
 									"--destination=" + registryName + "/" + tags[1],
@@ -483,7 +482,7 @@ func buildImage(tags []string, dockerfileFolder string) error {
 		}
 
 		log.Printf("[INFO] Docker Tags: %s", tags)
-		dockerfileSplit := strings.Split(dockerfileFolder, "/")
+		dockerfileSplit := strings.Split(dockerfileLocation, "/")
 
 		// Create a buffer
 		buf := new(bytes.Buffer)

--- a/backend/go-app/docker.go
+++ b/backend/go-app/docker.go
@@ -420,9 +420,7 @@ func buildImage(tags []string, dockerfileFolder string) error {
 								},
 							},
 						},
-						NodeSelector: map[string]string{
-							"node": backendNodeName,
-						},
+						NodeName:      backendNodeName,
 						RestartPolicy: corev1.RestartPolicyNever,
 						Volumes: []corev1.Volume{
 							{

--- a/backend/go-app/docker.go
+++ b/backend/go-app/docker.go
@@ -372,7 +372,6 @@ func buildImage(tags []string, dockerfileFolder string) error {
 		contextDir := strings.Replace(dockerfileFolder, "Dockerfile", "", -1)
 		contextDir = "/app/" + contextDir
 		log.Print("contextDir: ", contextDir)
-		dockerFile := "./Dockerfile"
 
 		client, err := getK8sClient()
 		if err != nil {

--- a/backend/go-app/go.sum
+++ b/backend/go-app/go.sum
@@ -334,8 +334,8 @@ github.com/sendgrid/sendgrid-go v3.14.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdR
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/shuffle/shuffle-shared v0.6.74 h1:os3BDSFZnl4U8ZgsTAY8IsTDADcMXhbc1rS9UMa0BIY=
-github.com/shuffle/shuffle-shared v0.6.74/go.mod h1:RAJiSFjmuKmijKTbbEf9A6Ojb+3/te7g71lED7JjPus=
+github.com/shuffle/shuffle-shared v0.6.77 h1:KKtM50xW2DLuRHINxhp3uXrNH0AhiwkeiiU93a8fB3A=
+github.com/shuffle/shuffle-shared v0.6.77/go.mod h1:RAJiSFjmuKmijKTbbEf9A6Ojb+3/te7g71lED7JjPus=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=


### PR DESCRIPTION
This PR fixes some issues I noticed with the app builder on the 2.0.0 branch.
I split my changes into 4 commits to make this PR more readable.

**go mod tidy**
This Commit is the result of running `go mod tidy` which just removes old references in the `go.sum` file.

**Use NodeName instead of NodeSelector**
I noticed that the `shuffle-app-builder` pod was not able to find a node in my k3s test cluster. This is because it expects the `node` label to be set. This is a non-standard label that is not always present. I changed the code to use `NodeName` instead. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename.

**Fix --dockerfile flag**
Kaniko crashes with the following error: `Error: error resolving dockerfile path: please provide a valid path to a Dockerfile within the build context with --dockerfile`.
The `--dockerfile` flag was set to `./Dockerfile`. It should either use an absolute path or a path relative to the build context in which case the `./` prefix needs to be removed. When using the `./` prefix, the path is relative to the current working directory when kaniko gets executed, and not relative to the build context.

**Use filepath module for constructing contextDir**
I noticed that file paths are manipulated using string functions. I changed the code to use the methods from the `filepath` module which should be more resilient and easier to read.
I also renamed `dockerfileFolder` to `dockerfileLocation`, because the variable point to the `Dockerfile` and not to the folder in which the `Dockerfile` lives.