### PR TITLE
Fix worker panic

### DIFF
--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -1301,9 +1301,6 @@ func handleExecutionResult(workflowExecution shuffle.WorkflowExecution) {
 			log.Printf("[ERROR] Unable to create docker client (3): %s", err)
 			return
 		}
-	}
-
-	if isKubernetes == "true" {
 		defer dockercli.Close()
 	}
 


### PR DESCRIPTION
I noticed the following runtime error in my worker logs.

```
2024/10/25 08:49:32 [DEBUG][dcd564dc-8311-4361-a0ae-4931be58f02c] NEWRESP (from app): {"execution_issues":"","reason":"App successfully finished","success":true}
2024/10/25 08:49:34 http: panic serving 10.42.0.198:53786: runtime error: invalid memory address or nil pointer dereference
goroutine 19254 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x1c467e0?, 0x32de990?})
	/usr/local/go/src/runtime/panic.go:785 +0x132
github.com/docker/docker/client.(*Client).Close(...)
	/go/pkg/mod/github.com/docker/docker@v26.1.5+incompatible/client/client.go:257
main.handleExecutionResult({{0xc001784cd0, 0x8}, {0xc001784ce0, 0x9}, {0xc000df6480, 0x24}, {0x327b9e0, 0x1}, {0xc000df64b0, 0x24}, ...})
	/app/Shuffle/functions/onprem/worker/worker.go:1769 +0x18fa
main.setWorkflowExecution({_, _}, {{0xc001385b80, 0x8}, {0xc001385b90, 0x9}, {0xc00149d110, 0x24}, {0x327b9e0, 0x1}, ...}, ...)
	/app/Shuffle/functions/onprem/worker/worker.go:147 +0x2c5
main.runWorkflowExecutionTransaction({_, _}, _, {_, _}, {{{0xc000c925b8, 0x7}, {0xc000c925d0, 0x5}, {0xc00048c9c0, ...}, ...}, ...}, ...)
	/app/Shuffle/functions/onprem/worker/worker.go:2473 +0x19c5
main.handleWorkflowQueue({0x2255050, 0xc0001a5260}, 0xc0011dbb80)
	/app/Shuffle/functions/onprem/worker/worker.go:2344 +0xaaa
net/http.HandlerFunc.ServeHTTP(0xc0011db900?, {0x2255050?, 0xc0001a5260?}, 0x10?)
	/usr/local/go/src/net/http/server.go:2220 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000718300, {0x2255050, 0xc0001a5260}, 0xc0011db7c0)
	/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
net/http.serverHandler.ServeHTTP({0x224db28?}, {0x2255050?, 0xc0001a5260?}, 0x6?)
	/usr/local/go/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc001318e10, {0x22642f0, 0xc0007331d0})
	/usr/local/go/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 1
	/usr/local/go/src/net/http/server.go:3360 +0x485
```

I changed the code to only call `dockercli.Close()` when the docker client was successfully created.
This should also fix the dockercli never being closed in docker environments, possibly causing a memory leak.
