### PR TITLE
FIX:docker client leaking FDs

### DIFF
--- a/backend/go-app/docker.go
+++ b/backend/go-app/docker.go
@@ -211,6 +211,7 @@ func fixTags(tags []string) []string {
 func buildImageMemory(fs billy.Filesystem, tags []string, dockerfileFolder string, downloadIfFail bool) error {
 	ctx := context.Background()
 	client, err := client.NewEnvClient()
+        defer client.Close()
 	if err != nil {
 		log.Printf("Unable to create docker client: %s", err)
 		return err
@@ -476,6 +477,7 @@ func buildImage(tags []string, dockerfileLocation string) error {
 
 		ctx := context.Background()
 		client, err := client.NewEnvClient()
+                defer client.Close()
 		if err != nil {
 			log.Printf("Unable to create docker client: %s", err)
 			return err


### PR DESCRIPTION
Defer close the old docker client when use it to build images. Avoid unlimited increase in the number of idle connections. Refer:https://github.com/Shuffle/Shuffle/issues/1543.
(Resubmit of https://github.com/Shuffle/Shuffle/pull/1544)