### PR TITLE
Added Image upload modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ shuffle-database/performance_analyzer_enabled.conf
 shuffle-database/rca_enabled.conf
 
 */package-lock.json
+shuffle-database/thread_contention_monitoring_enabled.conf

--- a/frontend/src/components/ImageUploadModal.jsx
+++ b/frontend/src/components/ImageUploadModal.jsx
@@ -1,0 +1,159 @@
+import React from "react";
+import AvatarEditor from "react-avatar-editor";
+import { toast } from "react-toastify";
+import theme from "../theme.jsx";
+
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  FormControl,
+  Divider,
+  Button,
+  Tooltip,
+} from "@mui/material";
+
+import {
+  AddAPhotoOutlined as AddAPhotoOutlinedIcon,
+  ZoomInOutlined as ZoomInOutlinedIcon,
+  ZoomOutOutlined as ZoomOutOutlinedIcon,
+  Loop as LoopIcon,
+} from "@mui/icons-material";
+
+const ImageUploadModal = ({
+  open,
+  onClose,
+  file,
+  fileBase64,
+  onSave,
+  title = "Upload Image",
+  upload,
+}) => {
+  const [scale, setScale] = React.useState(1);
+  const [rotate, setRotatation] = React.useState(0);
+  const [disableImageUpload, setDisableImageUpload] = React.useState(true);
+  const [imageUploadError, setImageUploadError] = React.useState("");
+
+  let editor;
+  const setEditorRef = (imgEditor) => {
+    editor = imgEditor;
+  };
+
+  const zoomIn = () => {
+    setScale(scale + 0.1);
+  };
+
+  const zoomOut = () => {
+    setScale(scale - 0.1);
+  };
+
+  const rotatation = () => {
+    setRotatation(rotate + 10);
+  };
+
+  const onPositionChange = () => {
+    setDisableImageUpload(false);
+  };
+
+  const handleSave = () => {
+    if (editor) {
+      try {
+        const canvas = editor.getImageScaledToCanvas();
+        onSave(canvas.toDataURL());
+      } catch (e) {
+        toast("Failed to set image. Replace it if this persists.");
+      }
+    }
+  };
+
+  const dividerStyle = { marginTop: 15, marginBottom: 15 };
+  const iconStyle = { margin: 5, width: 50, height: 50 };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        style: {
+          backgroundColor: theme.palette.inputColor,
+          color: "white",
+          minWidth: "300px",
+          minHeight: "300px",
+        },
+      }}
+    >
+      <FormControl>
+        <DialogTitle>
+          <div style={{ color: "rgba(255,255,255,0.9)" }}>{title}</div>
+        </DialogTitle>
+        {imageUploadError.length > 0 ? (
+          <div style={{ marginTop: 10 }}>Error: {imageUploadError}</div>
+        ) : null}
+        <DialogContent style={{ color: "rgba(255,255,255,0.65)" }}>
+          <AvatarEditor
+            ref={setEditorRef}
+            image={file.length > 0 ? file : fileBase64}
+            width={174}
+            height={174}
+            border={50}
+            color={[0, 0, 0, 0.6]}
+            scale={scale}
+            rotate={rotate}
+            onImageChange={onPositionChange}
+            onLoadSuccess={() => setRotatation(0)}
+          />
+          <Divider style={dividerStyle} />
+          <Tooltip title="New Icon">
+            <Button
+              variant="outlined"
+              component="label"
+              color="primary"
+              style={iconStyle}
+              onClick={() => {
+                if (upload && upload.current) {
+                  upload.current.click();
+                }
+              }}
+            >
+              <AddAPhotoOutlinedIcon
+                color="primary"
+              />
+            </Button>
+          </Tooltip>
+          <Tooltip title="Zoom In">
+            <Button variant="outlined" component="label" color="primary" style={iconStyle}>
+              <ZoomInOutlinedIcon onClick={zoomIn} color="primary" />
+            </Button>
+          </Tooltip>
+          <Tooltip title="Zoom Out">
+            <Button variant="outlined" component="label" color="primary" style={iconStyle}>
+              <ZoomOutOutlinedIcon onClick={zoomOut} color="primary" />
+            </Button>
+          </Tooltip>
+          <Tooltip title="Rotate">
+            <Button variant="outlined" component="label" color="primary" style={iconStyle}>
+              <LoopIcon onClick={rotatation} color="primary" />
+            </Button>
+          </Tooltip>
+          <Divider style={dividerStyle} />
+          <div style={{ marginTop: 15 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              disabled={disableImageUpload}
+              onClick={handleSave}
+              style={{ marginRight: 10 }}
+            >
+              Save
+            </Button>
+            <Button variant="contained" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </DialogContent>
+      </FormControl>
+    </Dialog>
+  );
+};
+
+export default ImageUploadModal; 

--- a/frontend/src/components/OrgHeader.jsx
+++ b/frontend/src/components/OrgHeader.jsx
@@ -1,21 +1,17 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import theme from "../theme.jsx";
 import { makeStyles } from "@mui/styles";
 import { toast } from 'react-toastify';
+import ImageUploadModal from "./ImageUploadModal";
 
 import {
-	Tooltip,
-	Grid,
-	Button,
-	TextField,
-	Typography,
-	IconButton,
+  Tooltip,
+  Button,
+  TextField,
 } from "@mui/material";
 
 import {
-	ExpandLess as ExpandLessIcon,
-	ExpandMore as ExpandMoreIcon,
-	Save as SaveIcon,
+  Save as SaveIcon,
 } from "@mui/icons-material";
 
 const useStyles = makeStyles({
@@ -32,13 +28,13 @@ const OrgHeader = (props) => {
     setSelectedOrganization,
     globalUrl,
     isCloud,
-		adminTab,
-  	handleEditOrg, 
+    adminTab,
+    handleEditOrg,
   } = props;
 
   const classes = useStyles();
 
-  var upload = "";
+  const upload = useRef(null);
   const defaultBranch = "master";
   const [orgName, setOrgName] = React.useState(selectedOrganization.name);
   const [orgDescription, setOrgDescription] = React.useState(
@@ -51,6 +47,66 @@ const OrgHeader = (props) => {
     selectedOrganization.image
   );
   const [expanded, setExpanded] = React.useState(false);
+  const [imageUploadError, setImageUploadError] = useState("");
+  const [openImageModal, setOpenImageModal] = useState(false);
+  const [scale, setScale] = useState(1);
+  const [rotate, setRotatation] = useState(0);
+  const [disableImageUpload, setDisableImageUpload] = useState(true);
+
+  let editor;
+  const setEditorRef = (imgEditor) => {
+    editor = imgEditor;
+  };
+
+  const zoomIn = () => {
+    setScale(scale + 0.1);
+  };
+
+  const zoomOut = () => {
+    setScale(scale - 0.1);
+  };
+
+  const rotatation = () => {
+    setRotatation(rotate + 10);
+  };
+
+  const onPositionChange = () => {
+    setDisableImageUpload(false);
+  };
+
+  const onCancelSaveOrgIcon = () => {
+    setFile("");
+    setOpenImageModal(false);
+    setImageUploadError("");
+  };
+
+  const onSaveOrgIcon = (newImage) => {
+    setFile("");
+    setFileBase64(newImage);
+    setOpenImageModal(false);
+    selectedOrganization.image = newImage;
+    setSelectedOrganization(selectedOrganization);
+  };
+
+  const dividerStyle = { marginTop: 15, marginBottom: 15 };
+  const orgIconStyle = { margin: 5, width: 50, height: 50 };
+
+
+  const imageUploadModalView = openImageModal ? (
+    <ImageUploadModal
+      open={openImageModal}
+      onClose={onCancelSaveOrgIcon}
+      file={file}
+      fileBase64={fileBase64}
+      onSave={onSaveOrgIcon}
+      title="Upload Organization Icon"
+      upload={upload}
+    />
+  ) : null;
+
+  const imageClickHandler = () => {
+    setOpenImageModal(true);
+  };
 
   if (file !== "") {
     const img = document.getElementById("logo");
@@ -134,7 +190,7 @@ const OrgHeader = (props) => {
               SSORequired: selectedOrganization?.sso_config?.SSORequired,
               auto_provision: selectedOrganization?.sso_config?.auto_provision,
             },
-						[],
+            [],
           )
         }
       >
@@ -145,7 +201,7 @@ const OrgHeader = (props) => {
 
   var imageData = file.length > 0 ? file : fileBase64;
   imageData = imageData === undefined || imageData.length === 0 ? defaultImage : imageData
-      
+
 
   const imageInfo = (
     <img
@@ -158,13 +214,22 @@ const OrgHeader = (props) => {
         minWidth: 174,
         minHeight: 174,
         objectFit: "contain",
-	    borderRadius: theme.shape.borderRadius,
+        borderRadius: theme.shape.borderRadius,
       }}
     />
   );
 
   return (
     <div>
+      <ImageUploadModal
+        open={openImageModal}
+        onClose={onCancelSaveOrgIcon}
+        file={file}
+        fileBase64={fileBase64}
+        onSave={onSaveOrgIcon}
+        title="Upload Organization Icon"
+        upload={upload}
+      />
       <div
         style={{
           color: "white",
@@ -188,16 +253,14 @@ const OrgHeader = (props) => {
               cursor: "pointer",
               maxWidth: 174,
               maxHeight: 174,
-			  borderRadius: theme.shape.borderRadius,
+              borderRadius: theme.shape.borderRadius,
             }}
-            onClick={() => {
-              upload.click();
-            }}
+            onClick={imageClickHandler}
           >
             <input
               hidden
               type="file"
-              ref={(ref) => (upload = ref)}
+              ref={upload}
               onChange={editHeaderImage}
             />
             {imageInfo}


### PR DESCRIPTION
**Added image editor modal in the admin page for organization overview icon.**
- [x] Resolved issue https://github.com/Shuffle/Shuffle/issues/1243 by implementing automatic scaling of base64 images on the Admin page to 174x174 pixels. 

- This fix involves using the existing image editor from the App Creator page to ensure consistent image display. The solution addresses the image resizing problem rather than a simple CSS adjustment, as discussed in the issue thread.

<img width="971" alt="Screenshot 2025-02-11 at 3 22 12 PM" src="https://github.com/user-attachments/assets/60ee9b9b-6124-4ce8-be38-55345e07b847" />
