### PR TITLE
fix helm release workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -35,9 +35,13 @@ jobs:
       - name: Set versions
         run: |
           if [[ ${{ github.event_name }} == 'release' ]]; then
-            VERSION="${{ github.event.release.tag_name }}"
+            TAG_NAME="${{ github.event.release.tag_name }}"
+
+            # Remove the v prefix
+            VERSION=${TAG_NAME#v}
+
             APP_VERSION="${VERSION}"
-            CHART_VERSION="${VERSION#v}" # Remove the v prefix
+            CHART_VERSION="${VERSION}"
           else
             APP_VERSION="nightly"
             CHART_VERSION="0.0.0-nightly-untagged-latest"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - nightly
     paths:
-      - "charts/**"
+      - "functions/kubernetes/charts/**"
 
 permissions:
   contents: read
@@ -32,16 +32,16 @@ jobs:
           sudo apt-get install helm -y --no-install-recommends
 
       - name: Set versions
-        id: set_versions
         run: |
           if [[ ${{ github.event_name }} == 'release' ]]; then
-            CHART_VERSION="${{ github.event.release.tag_name }}"
             APP_VERSION="${{ github.event.release.tag_name }}"
+            CHART_VERSION="${{ github.event.release.tag_name }}"
           else
-            CHART_VERSION="0.0.0-nightly-untagged-latest"
             APP_VERSION="nightly"
+            CHART_VERSION="0.0.0-nightly-untagged-latest"
           fi
 
+          echo "APP_VERSION set to ${APP_VERSION}"
           echo "CHART_VERSION set to ${CHART_VERSION}. Validating..."
 
           # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
@@ -54,17 +54,17 @@ jobs:
             exit 1;
           fi
 
-          echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_OUTPUT
-          echo "APP_VERSION=${APP_VERSION}" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION=${CHART_VERSION}" >> "$GITHUB_ENV"
+          echo "APP_VERSION=${APP_VERSION}" >> "$GITHUB_ENV"
 
       - name: Update helm dependencies
-        run: helm dependency update ./charts/shuffle
+        run: helm dependency update ./functions/kubernetes/charts/shuffle
 
       - name: Package Helm chart
-        run: helm package ./charts/shuffle --version "${CHART_VERSION}" --app-version="${APP_VERSION}" --destination ./charts
+        run: helm package ./functions/kubernetes/charts/shuffle --version "${CHART_VERSION}" --app-version="${APP_VERSION}" --destination ./functions/kubernetes/charts
 
       - name: Login to OCI registry (ghcr.io)
         run: helm registry login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push helm chart
-        run: helm push ./charts/shuffle-*.tgz oci://ghcr.io/shuffle/shuffle/charts
+        run: helm push ./functions/kubernetes/charts/shuffle-*.tgz oci://ghcr.io/shuffle/charts

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Set versions
         run: |
           if [[ ${{ github.event_name }} == 'release' ]]; then
-            APP_VERSION="${{ github.event.release.tag_name }}"
-            CHART_VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${{ github.event.release.tag_name }}"
+            APP_VERSION="${VERSION}"
+            CHART_VERSION="${VERSION#v}" # Remove the v prefix
           else
             APP_VERSION="nightly"
             CHART_VERSION="0.0.0-nightly-untagged-latest"


### PR DESCRIPTION
- Make workflow file compatible with 1ade199 which moved the chart into the functions/kubernetes subdirectory
- Log APP_VERSION for improved debugging
- Correctly pass env variables to subsequent steps
- Remove unneeded level of nesting in OCI registry

Normally, Helm charts should be versioned independently, so that you can make changes to the helm chart without releasing a new application version. But it was more convenient for now to use the information we already have available in the pipeline.

@frikky Let me know if you have an idea for an independent versioning strategy for the helm chart.