### PR TITLE
Enhancement: Local timezone support for date selection & API calls

### DIFF
--- a/frontend/src/components/RuntimeDebugger.jsx
+++ b/frontend/src/components/RuntimeDebugger.jsx
@@ -52,6 +52,8 @@ import {
   } from "@mui/material"
 
 import ClearIcon from '@mui/icons-material/Clear';
+import { formatLocalTime } from "../utils/dateUtils";
+import { getTimeZoneAbbreviation } from "../utils/dateUtils";
 
 const useStyles = makeStyles({
   notchedOutline: {
@@ -69,6 +71,7 @@ const RuntimeDebugger = (props) => {
 	const [endTime, setEndTime] = useState("")
 	const [startTime, setStartTime] = useState("")
 	const [totalCount, setTotalCount] = useState(0)
+	const [timezone, setTimezone] = useState("")
 
 	const [workflow, setWorkflow] = useState({})
 	const [ignoreOrg, setIgnoreOrg] = useState(false)
@@ -269,7 +272,7 @@ const RuntimeDebugger = (props) => {
 	  }
 
 	useEffect(() => {
-
+		setTimezone(getTimeZoneAbbreviation())
 		// Find workflow_id in url query
 		const urlParams = new URLSearchParams(window.location.search);
 		const workflowId = urlParams.get('workflow_id');
@@ -505,7 +508,7 @@ const RuntimeDebugger = (props) => {
 				)
 			},
 		  },
-		{ field: 'startTimestamp', headerName: 'Start time (UTC)', width: 160, 
+		{ field: 'startTimestamp', headerName: 'Start time ('+timezone+')', width: 160, 
 			renderCell: (params) => {
 				const comparisonTimestamp = params.row.completed_at === 0 ? timenowUnix : params.row.completed_at
 				const hasError = comparisonTimestamp-params.row.started_at > 300 
@@ -517,7 +520,7 @@ const RuntimeDebugger = (props) => {
 							//setEndTimestamp(params.row.endTimestamp)
 
 							// Make a new Date() from params.row.startTimestamp and set it in the endTime
-							const newEndTime = new Date(params.row.startTimestamp)
+							const newEndTime = new Date(formatLocalTime(params.row.startTimestamp))
 							if (newEndTime !== null && newEndTime !== undefined && newEndTime !== "" && newEndTime !== "Invalid Date") {
 								// Translate newEndTime to UTC no matter what timezone we are in. Based it on local()
 								// Plus 1 minute to make sure it comes in
@@ -530,13 +533,23 @@ const RuntimeDebugger = (props) => {
 								//setStartTime(dayjs(newEndTime))
 							}
 						}}>
-							{params.row.startTimestamp}
+							{formatLocalTime(params.row.startTimestamp)}
 						</span>
 					</Tooltip>
 				)
 			}
 		},
-		{ field: 'endTimestamp', headerName: 'End time (UTC)', width: 160, },
+		{ field: 'endTimestamp', headerName: 'End time ('+timezone+')', width: 160, 
+			renderCell: (params) => {
+				return (
+					<Tooltip title="" placement="top">
+						<span style={{cursor: "pointer"}}>
+							{formatLocalTime(params.row.endTimestamp)}
+						</span>
+					</Tooltip>
+				)
+			}
+		},
 	    {
 			field: 'id',
 			headerName: 'Explore',
@@ -655,7 +668,7 @@ const RuntimeDebugger = (props) => {
 					</div>
 				)
 			}
-		  },
+		},
 	]
 
 	useEffect(() => {
@@ -1122,7 +1135,9 @@ const RuntimeDebugger = (props) => {
 					  format="YYYY-MM-DD HH:mm:ss"
 					  value={endTime}
 					  onChange={handleEndTimeChange}
-					  renderInput={(params) => <TextField {...params} />}
+					  renderInput={(params) => {
+						return <TextField {...params} />;
+					  }}
 					/>
 				</LocalizationProvider>
 

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -1,0 +1,31 @@
+export const getTimeZoneAbbreviation = (tzName = Intl.DateTimeFormat().resolvedOptions().timeZone) => {
+    try {
+        const formatter = new Intl.DateTimeFormat("en", {
+            timeZone: tzName,
+            timeZoneName: "short",
+        });
+
+        const timeZonePart = formatter.formatToParts().find(part => part.type === "timeZoneName")?.value;
+
+        // Remove offset formats like "GMT+5:30" and keep known abbreviations
+        return timeZonePart.startsWith("GMT") ? tzName : timeZonePart;
+    } catch (error) {
+        return "Unknown Timezone";
+    }
+};
+
+
+export const formatLocalTime = (utcTimestamp) => {
+    const date = new Date(utcTimestamp + "Z"); // Ensure UTC handling
+
+    // Convert to local time and extract values
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0"); // Ensure 2-digit month
+    const day = String(date.getDate()).padStart(2, "0"); // Ensure 2-digit day
+    const hours = String(date.getHours()).padStart(2, "0"); // 24-hour format
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+};
+


### PR DESCRIPTION

feat: Convert timezone to user's local browser time  

### Changes:  
- [x] Converted start and end times to display in the user's local timezone in the table.  
- [x] Clicking on the start date sets the "Search Until" field to the selected local time.  
- [x] Ensured "Search From" remains in local time to avoid confusion.  
- [x] API calls are now made with the converted UTC values when the search button is clicked.  

<img width="1291" alt="Screenshot 2025-03-10 at 12 06 18 PM" src="https://github.com/user-attachments/assets/b6fe046b-75b6-4011-ae66-71dfa1a7a4d2" />


### Why this change?  
✅ Ensures a consistent user experience when viewing and selecting dates.  
✅ Prevents confusion between local time input and UTC API calls.  
✅ Improves clarity when filtering data based on time selections.  

### Related Issue - [#1641](https://github.com/Shuffle/Shuffle/issues/1641) 
