### PR TITLE
fix for auto memcached setup

### DIFF
--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -456,18 +456,20 @@ func deployServiceWorkers(image string) {
 		}
 	}
 
-	isMemcachedRunning, err := checkMemcached(ctx, dockercli)
-	if err != nil {
-		log.Printf("[ERROR] Failed checking memcached: %s", err)
-	}
-	if isMemcachedRunning == false {
-		log.Printf("[ERROR] Memcached is not running. Will try to deploy it.")
-		deployMemcached(dockercli)
-	}
+	// Only do this if no memcached is set manually
+	if os.Getenv("SHUFFLE_MEMCACHED") == "" {
+		isMemcachedRunning, err := checkMemcached(ctx, dockercli)
+		if err != nil {
+			log.Printf("[ERROR] Failed checking memcached: %s", err)
+		}
+		if isMemcachedRunning == false {
+			log.Printf("[ERROR] Memcached is not running. Will try to deploy it.")
+			deployMemcached(dockercli)
+		}
 
-	ip := "shuffle-cache"
-
-	os.Setenv("SHUFFLE_MEMCACHED", fmt.Sprintf("%s:11211", ip))
+		ip := "shuffle-cache"
+		os.Setenv("SHUFFLE_MEMCACHED", fmt.Sprintf("%s:11211", ip))
+	}
 
 	defaultNetworkAttach := false
 	if containerId != "" {


### PR DESCRIPTION
Heyo, let me know if this looks good. I also had an idea of writing it in a more "standard" way, like this:

```golang
if len(os.Getenv("SHUFFLE_MEMCACHED")) > 0 || os.Getenv("SHUFFLE_MEMCACHED") != "" {
 // do nothing
} else {
 // check and deploy memcached
}
```
Let me know what you think!