### PR TITLE
helm: set backend_url for workflow executions to cluster-internal address

### DIFF
--- a/functions/kubernetes/charts/shuffle/templates/backend/backend-cm-env.yaml
+++ b/functions/kubernetes/charts/shuffle/templates/backend/backend-cm-env.yaml
@@ -8,18 +8,20 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  BACKEND_PORT: "5001"
+  BACKEND_PORT: "{{ .Values.backend.containerPorts.http }}"
   {{- if .Values.shuffle.baseUrl }}
   BASE_URL: "{{ .Values.shuffle.baseUrl }}"
   SSO_REDIRECT_URL: "{{ .Values.shuffle.baseUrl }}"
   {{- else }}
-  BASE_URL: "http://{{ include "shuffle.backend.name" . }}:5001"
+  BASE_URL: "http://{{ include "shuffle.backend.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.backend.containerPorts.http }}"
   {{- end }}
   ORG_ID: "{{ .Values.shuffle.org }}"
   SHUFFLE_APP_DOWNLOAD_LOCATION: "{{ .Values.backend.apps.downloadLocation }}"
   SHUFFLE_DOWNLOAD_AUTH_BRANCH: "{{ .Values.backend.apps.downloadBranch }}"
   SHUFFLE_APP_FORCE_UPDATE: "{{ .Values.backend.apps.forceUpdate }}"
   SHUFFLE_CHAT_DISABLED: "true"
+  # Sets backend_url parameter for workflow execution to the cluster-internal shuffle-backend address
+  SHUFFLE_CLOUDRUN_URL: "http://{{ include "shuffle.backend.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.backend.containerPorts.http }}"
   SHUFFLE_OPENSEARCH_URL: {{ include "common.tplvalues.render" (dict "value" .Values.backend.openSearch.url "context" $) }}
   SHUFFLE_OPENSEARCH_USERNAME: "{{ .Values.backend.openSearch.username }}"
   SHUFFLE_OPENSEARCH_CERTIFICATE_FILE: "{{ .Values.backend.openSearch.certificateFile }}"

--- a/functions/kubernetes/charts/shuffle/templates/orborus/orborus-cm-env.yaml
+++ b/functions/kubernetes/charts/shuffle/templates/orborus/orborus-cm-env.yaml
@@ -11,7 +11,7 @@ data:
   ENVIRONMENT_NAME: "{{ .Values.shuffle.org }}"
   ORG_ID: "{{ .Values.shuffle.org }}"
   TZ: "{{ .Values.shuffle.timezone }}"
-  BASE_URL: "http://{{ include "shuffle.backend.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:5001"
+  BASE_URL: "http://{{ include "shuffle.backend.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.backend.containerPorts.http }}"
   KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"
   KUBERNETES_SERVICE_ACCOUNT: {{ include "shuffle.orborus.serviceAccount.name" . }}
   SHUFFLE_WORKER_IMAGE: "{{ include "shuffle.worker.image" . }}"

--- a/functions/kubernetes/charts/shuffle/templates/shuffle-app/shuffle-app-network-policy.yaml
+++ b/functions/kubernetes/charts/shuffle/templates/shuffle-app/shuffle-app-network-policy.yaml
@@ -29,6 +29,16 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
+    # Allow access to backend
+    - ports:
+      - port: {{ .Values.backend.containerPorts.http }}
+        protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels: {{ include "shuffle.backend.matchLabels" . | nindent 14 }}
     # Allow access to workers
     - ports:
         - port: 33333


### PR DESCRIPTION
Shuffle Backend sets the `backend_url` parameter when executing a workflow.
By default the value of the `BASE_URL` env variable is used.
This causes apps, which make requests to the backend (e.g. the subflow app), to send requests to the public shuffle base url.
e.g. the shuffle-subflow app will call https://shuffle.example.com instead of http://shuffle-backend.shuffle.svc.cluster.local:5001.
This causes networking overhead and potentially leads to connection failures in environments with strict network policies.

This PR also extends the default app egress policy to allow requests to the shuffle backend.
 
