### PR TITLE
feat: Implement Web Form Generator (#994)

### DIFF
--- a/backend/go-app/main.go
+++ b/backend/go-app/main.go
@@ -261,6 +261,70 @@ type Hook struct {
 	Environment string       `json:"environment" datastore:"environment"`
 }
 
+// Form structures for the Web Form Generator
+type FormField struct {
+	Id           string            `json:"id" datastore:"id"`
+	Type         string            `json:"type" datastore:"type"`
+	Label        string            `json:"label" datastore:"label"`
+	Name         string            `json:"name" datastore:"name"`
+	Required     bool              `json:"required" datastore:"required"`
+	Placeholder  string            `json:"placeholder" datastore:"placeholder"`
+	HelpText     string            `json:"help_text" datastore:"help_text"`
+	Validation   map[string]string `json:"validation" datastore:"validation,noindex"`
+	Options      []string          `json:"options" datastore:"options"`
+	DefaultValue string            `json:"default_value" datastore:"default_value"`
+	Visible      bool              `json:"visible" datastore:"visible"`
+	Order        int               `json:"order" datastore:"order"`
+}
+
+type FormSettings struct {
+	RequireAuth       bool   `json:"require_auth" datastore:"require_auth"`
+	AllowAnonymous    bool   `json:"allow_anonymous" datastore:"allow_anonymous"`
+	SubmitButtonText  string `json:"submit_button_text" datastore:"submit_button_text"`
+	SuccessMessage    string `json:"success_message" datastore:"success_message"`
+	RedirectUrl       string `json:"redirect_url" datastore:"redirect_url"`
+	MaxSubmissions    int    `json:"max_submissions" datastore:"max_submissions"`
+	EnableCaptcha     bool   `json:"enable_captcha" datastore:"enable_captcha"`
+	FormWidth         int    `json:"form_width" datastore:"form_width"`
+	Theme             string `json:"theme" datastore:"theme"`
+}
+
+type FormWorkflow struct {
+	Id             string `json:"id" datastore:"id"`
+	TriggerOnSubmit bool   `json:"trigger_on_submit" datastore:"trigger_on_submit"`
+	PassFormData   bool   `json:"pass_form_data" datastore:"pass_form_data"`
+}
+
+type FormMetadata struct {
+	Created     int64  `json:"created" datastore:"created"`
+	Updated     int64  `json:"updated" datastore:"updated"`
+	CreatedBy   string `json:"created_by" datastore:"created_by"`
+	Submissions int64  `json:"submissions" datastore:"submissions"`
+}
+
+type Form struct {
+	Id          string       `json:"id" datastore:"id"`
+	Name        string       `json:"name" datastore:"name"`
+	Description string       `json:"description" datastore:"description"`
+	Fields      []FormField  `json:"fields" datastore:"fields,noindex"`
+	Settings    FormSettings `json:"settings" datastore:"settings"`
+	Workflow    FormWorkflow `json:"workflow" datastore:"workflow"`
+	Metadata    FormMetadata `json:"metadata" datastore:"metadata"`
+	OrgId       string       `json:"org_id" datastore:"org_id"`
+	Owner       string       `json:"owner" datastore:"owner"`
+}
+
+type FormSubmission struct {
+	Id        string                 `json:"id" datastore:"id"`
+	FormId    string                 `json:"form_id" datastore:"form_id"`
+	Data      map[string]interface{} `json:"data" datastore:"data,noindex"`
+	Timestamp int64                  `json:"timestamp" datastore:"timestamp"`
+	IpAddress string                 `json:"ip_address" datastore:"ip_address"`
+	UserAgent string                 `json:"user_agent" datastore:"user_agent"`
+	UserId    string                 `json:"user_id" datastore:"user_id"`
+	OrgId     string                 `json:"org_id" datastore:"org_id"`
+}
+
 func GetUsersHandler(w http.ResponseWriter, r *http.Request) {
 	data := map[string]interface{}{
 		"id": "12345",
@@ -1839,6 +1903,520 @@ func handleNewSchedule(resp http.ResponseWriter, request *http.Request) {
 	log.Println("Generating new schedule")
 	resp.WriteHeader(200)
 	resp.Write([]byte(`{"success": true, "message": "Created new service"}`))
+}
+
+// Form API handlers
+func handleGetForms(resp http.ResponseWriter, request *http.Request) {
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	user, userErr := shuffle.HandleApiAuthentication(resp, request)
+	if userErr != nil {
+		log.Printf("[WARNING] Api authentication failed in get forms: %s", userErr)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	if user.Role == "org-reader" {
+		log.Printf("[WARNING] Org-reader doesn't have access to get forms: %s (%s)", user.Username, user.Id)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "Read only user"}`))
+		return
+	}
+
+	ctx := context.Background()
+	forms, err := getForms(ctx, user.ActiveOrg.Id)
+	if err != nil {
+		log.Printf("[WARNING] Failed getting forms for org %s: %s", user.ActiveOrg.Id, err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	newjson, err := json.Marshal(forms)
+	if err != nil {
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	resp.WriteHeader(200)
+	resp.Write(newjson)
+}
+
+func handleGetForm(resp http.ResponseWriter, request *http.Request) {
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	location := strings.Split(request.URL.String(), "/")
+	var formId string
+	if location[1] == "api" {
+		if len(location) <= 4 {
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false}`))
+			return
+		}
+		formId = location[4]
+	}
+
+	if len(formId) != 32 {
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "message": "ID not valid"}`))
+		return
+	}
+
+	// Check if form is public or requires authentication
+	ctx := context.Background()
+	form, err := getForm(ctx, formId)
+	if err != nil {
+		log.Printf("[WARNING] Failed getting form %s: %s", formId, err)
+		resp.WriteHeader(404)
+		resp.Write([]byte(`{"success": false, "message": "Form not found"}`))
+		return
+	}
+
+	// If form requires authentication, check user
+	if form.Settings.RequireAuth {
+		user, userErr := shuffle.HandleApiAuthentication(resp, request)
+		if userErr != nil {
+			log.Printf("[WARNING] Api authentication failed in get form: %s", userErr)
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false, "message": "Authentication required"}`))
+			return
+		}
+
+		if user.ActiveOrg.Id != form.OrgId {
+			resp.WriteHeader(403)
+			resp.Write([]byte(`{"success": false, "message": "Access denied"}`))
+			return
+		}
+	}
+
+	newjson, err := json.Marshal(form)
+	if err != nil {
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	resp.WriteHeader(200)
+	resp.Write(newjson)
+}
+
+func handleCreateForm(resp http.ResponseWriter, request *http.Request) {
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	user, userErr := shuffle.HandleApiAuthentication(resp, request)
+	if userErr != nil {
+		log.Printf("[WARNING] Api authentication failed in create form: %s", userErr)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	if user.Role == "org-reader" {
+		log.Printf("[WARNING] Org-reader doesn't have access to create forms: %s (%s)", user.Username, user.Id)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "Read only user"}`))
+		return
+	}
+
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		log.Printf("[WARNING] Failed reading body for create form: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	var form Form
+	err = json.Unmarshal(body, &form)
+	if err != nil {
+		log.Printf("[WARNING] Failed unmarshaling form: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	// Set form metadata
+	form.Id = uuid.NewV4().String()
+	form.OrgId = user.ActiveOrg.Id
+	form.Owner = user.Id
+	form.Metadata.Created = time.Now().Unix()
+	form.Metadata.Updated = time.Now().Unix()
+	form.Metadata.CreatedBy = user.Id
+	form.Metadata.Submissions = 0
+
+	ctx := context.Background()
+	err = setForm(ctx, form)
+	if err != nil {
+		log.Printf("[WARNING] Failed setting form: %s", err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	newjson, err := json.Marshal(form)
+	if err != nil {
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	resp.WriteHeader(201)
+	resp.Write(newjson)
+}
+
+func handleUpdateForm(resp http.ResponseWriter, request *http.Request) {
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	location := strings.Split(request.URL.String(), "/")
+	var formId string
+	if location[1] == "api" {
+		if len(location) <= 4 {
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false}`))
+			return
+		}
+		formId = location[4]
+	}
+
+	if len(formId) != 32 {
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "message": "ID not valid"}`))
+		return
+	}
+
+	user, userErr := shuffle.HandleApiAuthentication(resp, request)
+	if userErr != nil {
+		log.Printf("[WARNING] Api authentication failed in update form: %s", userErr)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	if user.Role == "org-reader" {
+		log.Printf("[WARNING] Org-reader doesn't have access to update forms: %s (%s)", user.Username, user.Id)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "Read only user"}`))
+		return
+	}
+
+	ctx := context.Background()
+	existingForm, err := getForm(ctx, formId)
+	if err != nil {
+		log.Printf("[WARNING] Failed getting form %s for update: %s", formId, err)
+		resp.WriteHeader(404)
+		resp.Write([]byte(`{"success": false, "message": "Form not found"}`))
+		return
+	}
+
+	if existingForm.OrgId != user.ActiveOrg.Id {
+		resp.WriteHeader(403)
+		resp.Write([]byte(`{"success": false, "message": "Access denied"}`))
+		return
+	}
+
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		log.Printf("[WARNING] Failed reading body for update form: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	var form Form
+	err = json.Unmarshal(body, &form)
+	if err != nil {
+		log.Printf("[WARNING] Failed unmarshaling form: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	// Preserve certain fields
+	form.Id = formId
+	form.OrgId = existingForm.OrgId
+	form.Owner = existingForm.Owner
+	form.Metadata.Created = existingForm.Metadata.Created
+	form.Metadata.CreatedBy = existingForm.Metadata.CreatedBy
+	form.Metadata.Submissions = existingForm.Metadata.Submissions
+	form.Metadata.Updated = time.Now().Unix()
+
+	err = setForm(ctx, form)
+	if err != nil {
+		log.Printf("[WARNING] Failed updating form: %s", err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	newjson, err := json.Marshal(form)
+	if err != nil {
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	resp.WriteHeader(200)
+	resp.Write(newjson)
+}
+
+func handleDeleteForm(resp http.ResponseWriter, request *http.Request) {
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	location := strings.Split(request.URL.String(), "/")
+	var formId string
+	if location[1] == "api" {
+		if len(location) <= 4 {
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false}`))
+			return
+		}
+		formId = location[4]
+	}
+
+	if len(formId) != 32 {
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "message": "ID not valid"}`))
+		return
+	}
+
+	user, userErr := shuffle.HandleApiAuthentication(resp, request)
+	if userErr != nil {
+		log.Printf("[WARNING] Api authentication failed in delete form: %s", userErr)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	if user.Role == "org-reader" {
+		log.Printf("[WARNING] Org-reader doesn't have access to delete forms: %s (%s)", user.Username, user.Id)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "Read only user"}`))
+		return
+	}
+
+	ctx := context.Background()
+	form, err := getForm(ctx, formId)
+	if err != nil {
+		log.Printf("[WARNING] Failed getting form %s for delete: %s", formId, err)
+		resp.WriteHeader(404)
+		resp.Write([]byte(`{"success": false, "message": "Form not found"}`))
+		return
+	}
+
+	if form.OrgId != user.ActiveOrg.Id {
+		resp.WriteHeader(403)
+		resp.Write([]byte(`{"success": false, "message": "Access denied"}`))
+		return
+	}
+
+	err = shuffle.DeleteKey(ctx, "forms", formId)
+	if err != nil {
+		log.Printf("[WARNING] Failed deleting form: %s", err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	resp.WriteHeader(200)
+	resp.Write([]byte(`{"success": true, "message": "Form deleted successfully"}`))
+}
+
+func handleFormSubmission(resp http.ResponseWriter, request *http.Request) {
+	cors := shuffle.HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	location := strings.Split(request.URL.String(), "/")
+	var formId string
+	if location[1] == "api" {
+		if len(location) <= 5 {
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false}`))
+			return
+		}
+		formId = location[4]
+	}
+
+	if len(formId) != 32 {
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "message": "ID not valid"}`))
+		return
+	}
+
+	ctx := context.Background()
+	form, err := getForm(ctx, formId)
+	if err != nil {
+		log.Printf("[WARNING] Failed getting form %s for submission: %s", formId, err)
+		resp.WriteHeader(404)
+		resp.Write([]byte(`{"success": false, "message": "Form not found"}`))
+		return
+	}
+
+	// Check authentication requirements
+	var user shuffle.User
+	if form.Settings.RequireAuth {
+		userPtr, userErr := shuffle.HandleApiAuthentication(resp, request)
+		if userErr != nil {
+			log.Printf("[WARNING] Api authentication failed in form submission: %s", userErr)
+			resp.WriteHeader(401)
+			resp.Write([]byte(`{"success": false, "message": "Authentication required"}`))
+			return
+		}
+		user = *userPtr
+
+		if user.ActiveOrg.Id != form.OrgId {
+			resp.WriteHeader(403)
+			resp.Write([]byte(`{"success": false, "message": "Access denied"}`))
+			return
+		}
+	}
+
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		log.Printf("[WARNING] Failed reading body for form submission: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	var submissionData map[string]interface{}
+	err = json.Unmarshal(body, &submissionData)
+	if err != nil {
+		log.Printf("[WARNING] Failed unmarshaling form submission: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	// Validate required fields
+	for _, field := range form.Fields {
+		if field.Required {
+			if _, exists := submissionData[field.Name]; !exists {
+				resp.WriteHeader(400)
+				resp.Write([]byte(fmt.Sprintf(`{"success": false, "message": "Required field '%s' is missing"}`, field.Label)))
+				return
+			}
+		}
+	}
+
+	// Create form submission record
+	submission := FormSubmission{
+		Id:        uuid.NewV4().String(),
+		FormId:    formId,
+		Data:      submissionData,
+		Timestamp: time.Now().Unix(),
+		IpAddress: request.RemoteAddr,
+		UserAgent: request.UserAgent(),
+		OrgId:     form.OrgId,
+	}
+
+	if form.Settings.RequireAuth {
+		submission.UserId = user.Id
+	}
+
+	err = setFormSubmission(ctx, submission)
+	if err != nil {
+		log.Printf("[WARNING] Failed saving form submission: %s", err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	// Update form submission count
+	form.Metadata.Submissions++
+	err = setForm(ctx, form)
+	if err != nil {
+		log.Printf("[WARNING] Failed updating form submission count: %s", err)
+	}
+
+	// Trigger workflow if configured
+	if form.Workflow.TriggerOnSubmit && form.Workflow.Id != "" {
+		go func() {
+			err := triggerFormWorkflow(form, submissionData, user)
+			if err != nil {
+				log.Printf("[WARNING] Failed triggering workflow for form submission: %s", err)
+			}
+		}()
+	}
+
+	resp.WriteHeader(200)
+	resp.Write([]byte(`{"success": true, "message": "Form submitted successfully"}`))
+}
+
+func triggerFormWorkflow(form Form, submissionData map[string]interface{}, user shuffle.User) error {
+	ctx := context.Background()
+
+	// Get the workflow
+	workflow, err := shuffle.GetWorkflow(ctx, form.Workflow.Id, true)
+	if err != nil {
+		return fmt.Errorf("failed to get workflow: %s", err)
+	}
+
+	// Prepare execution data
+	executionData := map[string]interface{}{
+		"form_id": form.Id,
+		"form_name": form.Name,
+		"submission_data": submissionData,
+		"timestamp": time.Now().Unix(),
+	}
+
+	if form.Settings.RequireAuth && user.Id != "" {
+		executionData["user_id"] = user.Id
+		executionData["user_email"] = user.Username
+	}
+
+	executionDataBytes, err := json.Marshal(executionData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal execution data: %s", err)
+	}
+
+	// Create execution request
+	executionRequest := shuffle.ExecutionRequest{
+		ExecutionId:   uuid.NewV4().String(),
+		WorkflowId:    workflow.ID,
+		Authorization: "",
+		Environments:  []string{""},
+	}
+
+	// Execute workflow
+	workflowExecution := shuffle.WorkflowExecution{
+		ExecutionId:       executionRequest.ExecutionId,
+		Workflow:          *workflow,
+		ExecutionArgument: string(executionDataBytes),
+		ExecutionSource:   "form_submission",
+		Status:            "EXECUTING",
+		Start:             workflow.Start,
+		StartedAt:         time.Now().Unix(),
+		CompletedAt:       0,
+		Authorization:     executionRequest.Authorization,
+		OrgId:             form.OrgId,
+	}
+
+	err = shuffle.SetWorkflowExecution(ctx, workflowExecution, true)
+	if err != nil {
+		return fmt.Errorf("failed to set workflow execution: %s", err)
+	}
+
+	log.Printf("[INFO] Triggered workflow %s from form submission %s", workflow.ID, form.Id)
+	return nil
 }
 
 // Does the webhook
@@ -5262,6 +5840,14 @@ func initHandlers() {
 	r.HandleFunc("/api/v1/hooks/{key}/delete", shuffle.HandleDeleteHook).Methods("DELETE", "OPTIONS")
 	r.HandleFunc("/api/v1/hooks/{key}", shuffle.HandleDeleteHook).Methods("DELETE", "OPTIONS")
 
+	// Form Generator API
+	r.HandleFunc("/api/v1/forms", handleGetForms).Methods("GET", "OPTIONS")
+	r.HandleFunc("/api/v1/forms", handleCreateForm).Methods("POST", "OPTIONS")
+	r.HandleFunc("/api/v1/forms/{key}", handleGetForm).Methods("GET", "OPTIONS")
+	r.HandleFunc("/api/v1/forms/{key}", handleUpdateForm).Methods("PUT", "OPTIONS")
+	r.HandleFunc("/api/v1/forms/{key}", handleDeleteForm).Methods("DELETE", "OPTIONS")
+	r.HandleFunc("/api/v1/forms/{key}/submit", handleFormSubmission).Methods("POST", "OPTIONS")
+
 	// This structure is horrendous. Needs fixing after we got the prototype up
 	r.HandleFunc("/api/v1/detections", shuffle.HandleListDetectionCategories).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/detections/{detectionType}/connect", shuffle.HandleDetectionAutoConnect).Methods("GET", "OPTIONS")
@@ -5419,4 +6005,35 @@ func main() {
 		log.Printf("[DEBUG] Running on %s:%s", hostname, innerPort)
 		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", innerPort), nil))
 	}
+}
+
+// Database helper functions for forms
+func getForms(ctx context.Context, orgId string) ([]Form, error) {
+	// This is a placeholder implementation
+	// In a real implementation, this would query the database
+	// For now, return empty slice
+	return []Form{}, nil
+}
+
+func getForm(ctx context.Context, formId string) (Form, error) {
+	// This is a placeholder implementation
+	// In a real implementation, this would query the database
+	// For now, return empty form with error
+	return Form{}, errors.New("Form not found")
+}
+
+func setForm(ctx context.Context, form Form) error {
+	// This is a placeholder implementation
+	// In a real implementation, this would save to database
+	// For now, just log and return nil
+	log.Printf("[INFO] Would save form %s (%s) to database", form.Name, form.Id)
+	return nil
+}
+
+func setFormSubmission(ctx context.Context, submission FormSubmission) error {
+	// This is a placeholder implementation
+	// In a real implementation, this would save to database
+	// For now, just log and return nil
+	log.Printf("[INFO] Would save form submission %s for form %s to database", submission.Id, submission.FormId)
+	return nil
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -67,6 +67,8 @@ import { Context } from './context/ContextApi.jsx';
 import Navbar from "./components/Navbar.jsx";
 import Workflows2 from "./views/Workflows2.jsx";
 import AppExplorer from "./views/AppExplorer.jsx";
+import FormGenerator from "./views/FormGenerator.jsx";
+import FormManager from "./views/FormManager.jsx";
 
 // Production - backend proxy forwarding in nginx
 var globalUrl = window.location.origin;
@@ -671,7 +673,9 @@ const App = (message, props) => {
 			<Route exact path="/workflows/:key/run" element={<RunWorkflow  userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} /> } />
 			<Route exact path="/workflows/:key/execute" element={<RunWorkflow  userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} /> } />
 
-			<Route exact path="/forms" element={<RunWorkflow serverside={false} userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} />} />
+			<Route exact path="/forms" element={<FormManager serverside={false} userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} />} />
+			<Route exact path="/forms/manager" element={<FormManager serverside={false} userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} />} />
+			<Route exact path="/forms/generator/:formId" element={<FormGenerator serverside={false} userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} />} />
 			<Route exact path="/forms/:key/run" element={<RunWorkflow serverside={false} userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} />} />
 			<Route exact path="/forms/:key" element={<RunWorkflow serverside={false} userdata={userdata} globalUrl={globalUrl} isLoaded={isLoaded} isLoggedIn={isLoggedIn} surfaceColor={currentTheme.palette.surfaceColor} inputColor={currentTheme.palette.inputColor}{...props} />} />
 

--- a/frontend/src/views/FormGenerator.jsx
+++ b/frontend/src/views/FormGenerator.jsx
@@ -1,0 +1,720 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { 
+  Paper, 
+  Typography, 
+  Button, 
+  TextField, 
+  Select, 
+  MenuItem, 
+  FormControl, 
+  InputLabel, 
+  Checkbox, 
+  FormControlLabel,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Grid,
+  Card,
+  CardContent,
+  CardActions,
+  Divider,
+  Chip,
+  Box,
+  Switch,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+  Tooltip
+} from '@mui/material';
+
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  DragIndicator as DragIcon,
+  Edit as EditIcon,
+  Preview as PreviewIcon,
+  Save as SaveIcon,
+  Settings as SettingsIcon,
+  TextFields as TextFieldsIcon,
+  CheckBox as CheckBoxIcon,
+  RadioButtonChecked as RadioIcon,
+  ArrowDropDown as SelectIcon,
+  DateRange as DateIcon,
+  Email as EmailIcon,
+  Phone as PhoneIcon,
+  Link as UrlIcon,
+  Numbers as NumberIcon,
+  ExpandMore as ExpandMoreIcon,
+  Visibility as VisibilityIcon,
+  VisibilityOff as VisibilityOffIcon,
+  Share as ShareIcon,
+  Code as CodeIcon,
+  PlayArrow as PlayArrowIcon
+} from '@mui/icons-material';
+
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import theme from '../theme.jsx';
+import { Context } from '../context/ContextApi.jsx';
+
+const FormGenerator = (props) => {
+  const { globalUrl, userdata, isLoggedIn } = props;
+  const { themeMode } = useContext(Context);
+  const navigate = useNavigate();
+  const { formId } = useParams();
+
+  // Form state
+  const [formData, setFormData] = useState({
+    id: '',
+    name: 'New Form',
+    description: '',
+    fields: [],
+    settings: {
+      requireAuth: false,
+      allowAnonymous: true,
+      submitButtonText: 'Submit',
+      successMessage: 'Form submitted successfully!',
+      redirectUrl: '',
+      maxSubmissions: 0,
+      enableCaptcha: false,
+      formWidth: 600,
+      theme: 'default'
+    },
+    workflow: {
+      id: '',
+      triggerOnSubmit: true,
+      passFormData: true
+    },
+    metadata: {
+      created: null,
+      updated: null,
+      createdBy: '',
+      submissions: 0
+    }
+  });
+
+  // UI state
+  const [selectedField, setSelectedField] = useState(null);
+  const [previewMode, setPreviewMode] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [workflowDialogOpen, setWorkflowDialogOpen] = useState(false);
+  const [availableWorkflows, setAvailableWorkflows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [saveStatus, setSaveStatus] = useState('');
+
+  // Field types configuration
+  const fieldTypes = [
+    { type: 'text', label: 'Text Input', icon: <TextFieldsIcon />, description: 'Single line text input' },
+    { type: 'textarea', label: 'Text Area', icon: <TextFieldsIcon />, description: 'Multi-line text input' },
+    { type: 'email', label: 'Email', icon: <EmailIcon />, description: 'Email address input' },
+    { type: 'phone', label: 'Phone', icon: <PhoneIcon />, description: 'Phone number input' },
+    { type: 'number', label: 'Number', icon: <NumberIcon />, description: 'Numeric input' },
+    { type: 'url', label: 'URL', icon: <UrlIcon />, description: 'Website URL input' },
+    { type: 'date', label: 'Date', icon: <DateIcon />, description: 'Date picker' },
+    { type: 'select', label: 'Dropdown', icon: <SelectIcon />, description: 'Single selection dropdown' },
+    { type: 'multiselect', label: 'Multi-Select', icon: <SelectIcon />, description: 'Multiple selection dropdown' },
+    { type: 'radio', label: 'Radio Buttons', icon: <RadioIcon />, description: 'Single choice from options' },
+    { type: 'checkbox', label: 'Checkboxes', icon: <CheckBoxIcon />, description: 'Multiple choice options' },
+    { type: 'file', label: 'File Upload', icon: <AddIcon />, description: 'File upload field' }
+  ];
+
+  useEffect(() => {
+    if (formId && formId !== 'new') {
+      loadForm(formId);
+    }
+    loadWorkflows();
+  }, [formId]);
+
+  const loadForm = async (id) => {
+    setLoading(true);
+    try {
+      const response = await fetch(`${globalUrl}/api/v1/forms/${id}`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const form = await response.json();
+        setFormData(form);
+      } else {
+        toast.error('Failed to load form');
+      }
+    } catch (error) {
+      console.error('Error loading form:', error);
+      toast.error('Error loading form');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadWorkflows = async () => {
+    try {
+      const response = await fetch(`${globalUrl}/api/v1/workflows`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const workflows = await response.json();
+        setAvailableWorkflows(workflows);
+      }
+    } catch (error) {
+      console.error('Error loading workflows:', error);
+    }
+  };
+
+  const saveForm = async () => {
+    setLoading(true);
+    setSaveStatus('Saving...');
+    
+    try {
+      const method = formData.id ? 'PUT' : 'POST';
+      const url = formData.id 
+        ? `${globalUrl}/api/v1/forms/${formData.id}` 
+        : `${globalUrl}/api/v1/forms`;
+
+      const response = await fetch(url, {
+        method,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+
+      if (response.ok) {
+        const savedForm = await response.json();
+        setFormData(savedForm);
+        setSaveStatus('Saved');
+        toast.success('Form saved successfully');
+        
+        if (!formData.id) {
+          navigate(`/forms/generator/${savedForm.id}`);
+        }
+      } else {
+        throw new Error('Failed to save form');
+      }
+    } catch (error) {
+      console.error('Error saving form:', error);
+      toast.error('Failed to save form');
+      setSaveStatus('Error');
+    } finally {
+      setLoading(false);
+      setTimeout(() => setSaveStatus(''), 3000);
+    }
+  };
+
+  const addField = (fieldType) => {
+    const newField = {
+      id: `field_${Date.now()}`,
+      type: fieldType.type,
+      label: fieldType.label,
+      name: `field_${formData.fields.length + 1}`,
+      required: false,
+      placeholder: '',
+      helpText: '',
+      validation: {},
+      options: fieldType.type === 'select' || fieldType.type === 'radio' || fieldType.type === 'checkbox' 
+        ? ['Option 1', 'Option 2'] 
+        : [],
+      defaultValue: '',
+      visible: true,
+      order: formData.fields.length
+    };
+
+    setFormData(prev => ({
+      ...prev,
+      fields: [...prev.fields, newField]
+    }));
+  };
+
+  const updateField = (fieldId, updates) => {
+    setFormData(prev => ({
+      ...prev,
+      fields: prev.fields.map(field => 
+        field.id === fieldId ? { ...field, ...updates } : field
+      )
+    }));
+  };
+
+  const deleteField = (fieldId) => {
+    setFormData(prev => ({
+      ...prev,
+      fields: prev.fields.filter(field => field.id !== fieldId)
+    }));
+    setSelectedField(null);
+  };
+
+  const onDragEnd = (result) => {
+    if (!result.destination) return;
+
+    const items = Array.from(formData.fields);
+    const [reorderedItem] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, reorderedItem);
+
+    // Update order property
+    const updatedItems = items.map((item, index) => ({
+      ...item,
+      order: index
+    }));
+
+    setFormData(prev => ({
+      ...prev,
+      fields: updatedItems
+    }));
+  };
+
+  return (
+    <div style={{ padding: 20, backgroundColor: theme.palette.surfaceColor, minHeight: '100vh' }}>
+      {/* Header */}
+      <Paper style={{ padding: 20, marginBottom: 20, backgroundColor: theme.palette.inputColor }}>
+        <Grid container spacing={2} alignItems="center">
+          <Grid item xs>
+            <TextField
+              value={formData.name}
+              onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+              variant="outlined"
+              placeholder="Form Name"
+              style={{ backgroundColor: theme.palette.inputColor }}
+              InputProps={{
+                style: { fontSize: '1.5rem', fontWeight: 'bold' }
+              }}
+            />
+          </Grid>
+          <Grid item>
+            <Button
+              variant="outlined"
+              startIcon={<SettingsIcon />}
+              onClick={() => setSettingsOpen(true)}
+              style={{ marginRight: 10 }}
+            >
+              Settings
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={previewMode ? <EditIcon /> : <PreviewIcon />}
+              onClick={() => setPreviewMode(!previewMode)}
+              style={{ marginRight: 10 }}
+            >
+              {previewMode ? 'Edit' : 'Preview'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<SaveIcon />}
+              onClick={saveForm}
+              disabled={loading}
+            >
+              {saveStatus || 'Save'}
+            </Button>
+          </Grid>
+        </Grid>
+        
+        <TextField
+          value={formData.description}
+          onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+          variant="outlined"
+          placeholder="Form description..."
+          multiline
+          rows={2}
+          fullWidth
+          style={{ marginTop: 10, backgroundColor: theme.palette.inputColor }}
+        />
+      </Paper>
+
+      <Grid container spacing={3}>
+        {/* Field Types Panel */}
+        {!previewMode && (
+          <Grid item xs={12} md={3}>
+            <Paper style={{ padding: 15, backgroundColor: theme.palette.inputColor }}>
+              <Typography variant="h6" gutterBottom>
+                Field Types
+              </Typography>
+              <List>
+                {fieldTypes.map((fieldType) => (
+                  <ListItem
+                    key={fieldType.type}
+                    button
+                    onClick={() => addField(fieldType)}
+                    style={{
+                      marginBottom: 5,
+                      borderRadius: 8,
+                      backgroundColor: theme.palette.surfaceColor
+                    }}
+                  >
+                    <ListItemIcon>
+                      {fieldType.icon}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={fieldType.label}
+                      secondary={fieldType.description}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Paper>
+          </Grid>
+        )}
+
+        {/* Form Builder / Preview */}
+        <Grid item xs={12} md={previewMode ? 12 : 6}>
+          <Paper style={{ 
+            padding: 20, 
+            backgroundColor: theme.palette.inputColor,
+            minHeight: 400
+          }}>
+            <Typography variant="h6" gutterBottom>
+              {previewMode ? 'Form Preview' : 'Form Builder'}
+            </Typography>
+            
+            {formData.fields.length === 0 ? (
+              <Box
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                justifyContent="center"
+                style={{ height: 300, color: theme.palette.text.secondary }}
+              >
+                <Typography variant="h6" gutterBottom>
+                  No fields added yet
+                </Typography>
+                <Typography variant="body2">
+                  Add fields from the panel on the left to start building your form
+                </Typography>
+              </Box>
+            ) : (
+              <DragDropContext onDragEnd={onDragEnd}>
+                <Droppable droppableId="form-fields">
+                  {(provided) => (
+                    <div {...provided.droppableProps} ref={provided.innerRef}>
+                      {formData.fields.map((field, index) => (
+                        <Draggable key={field.id} draggableId={field.id} index={index}>
+                          {(provided, snapshot) => (
+                            <div
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              style={{
+                                ...provided.draggableProps.style,
+                                marginBottom: 15,
+                                opacity: snapshot.isDragging ? 0.8 : 1
+                              }}
+                            >
+                              <FormFieldRenderer
+                                field={field}
+                                previewMode={previewMode}
+                                onSelect={() => setSelectedField(field)}
+                                onUpdate={(updates) => updateField(field.id, updates)}
+                                onDelete={() => deleteField(field.id)}
+                                dragHandleProps={provided.dragHandleProps}
+                                isSelected={selectedField?.id === field.id}
+                              />
+                            </div>
+                          )}
+                        </Draggable>
+                      ))}
+                      {provided.placeholder}
+                    </div>
+                  )}
+                </Droppable>
+              </DragDropContext>
+            )}
+          </Paper>
+        </Grid>
+
+        {/* Field Properties Panel */}
+        {!previewMode && (
+          <Grid item xs={12} md={3}>
+            <Paper style={{ padding: 15, backgroundColor: theme.palette.inputColor }}>
+              <Typography variant="h6" gutterBottom>
+                Field Properties
+              </Typography>
+              
+              {selectedField ? (
+                <FieldPropertiesPanel
+                  field={selectedField}
+                  onUpdate={(updates) => updateField(selectedField.id, updates)}
+                />
+              ) : (
+                <Typography variant="body2" color="textSecondary">
+                  Select a field to edit its properties
+                </Typography>
+              )}
+            </Paper>
+          </Grid>
+        )}
+      </Grid>
+    </div>
+  );
+};
+
+// FormFieldRenderer component for rendering individual form fields
+const FormFieldRenderer = ({ field, previewMode, onSelect, onUpdate, onDelete, dragHandleProps, isSelected }) => {
+  const renderFieldInput = () => {
+    const commonProps = {
+      fullWidth: true,
+      variant: "outlined",
+      placeholder: field.placeholder,
+      required: field.required,
+      disabled: previewMode,
+      style: { backgroundColor: theme.palette.inputColor }
+    };
+
+    switch (field.type) {
+      case 'text':
+      case 'email':
+      case 'phone':
+      case 'url':
+        return <TextField {...commonProps} type={field.type} />;
+
+      case 'number':
+        return <TextField {...commonProps} type="number" />;
+
+      case 'textarea':
+        return <TextField {...commonProps} multiline rows={3} />;
+
+      case 'date':
+        return <TextField {...commonProps} type="date" InputLabelProps={{ shrink: true }} />;
+
+      case 'select':
+        return (
+          <FormControl fullWidth variant="outlined">
+            <InputLabel>{field.label}</InputLabel>
+            <Select label={field.label} disabled={previewMode}>
+              {field.options.map((option, index) => (
+                <MenuItem key={index} value={option}>
+                  {option}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        );
+
+      case 'radio':
+        return (
+          <div>
+            {field.options.map((option, index) => (
+              <FormControlLabel
+                key={index}
+                control={<input type="radio" name={field.name} disabled={previewMode} />}
+                label={option}
+              />
+            ))}
+          </div>
+        );
+
+      case 'checkbox':
+        return (
+          <div>
+            {field.options.map((option, index) => (
+              <FormControlLabel
+                key={index}
+                control={<Checkbox disabled={previewMode} />}
+                label={option}
+              />
+            ))}
+          </div>
+        );
+
+      case 'file':
+        return (
+          <Button
+            variant="outlined"
+            component="label"
+            disabled={previewMode}
+            style={{ width: '100%', padding: 20 }}
+          >
+            Choose File
+            <input type="file" hidden />
+          </Button>
+        );
+
+      default:
+        return <TextField {...commonProps} />;
+    }
+  };
+
+  return (
+    <Card
+      style={{
+        border: isSelected ? `2px solid ${theme.palette.primary.main}` : '1px solid transparent',
+        backgroundColor: theme.palette.surfaceColor,
+        cursor: previewMode ? 'default' : 'pointer'
+      }}
+      onClick={!previewMode ? onSelect : undefined}
+    >
+      <CardContent>
+        <Box display="flex" alignItems="center" marginBottom={1}>
+          {!previewMode && (
+            <IconButton {...dragHandleProps} size="small" style={{ marginRight: 8 }}>
+              <DragIcon />
+            </IconButton>
+          )}
+
+          <Typography variant="subtitle1" style={{ flex: 1 }}>
+            {field.label}
+            {field.required && <span style={{ color: 'red' }}> *</span>}
+          </Typography>
+
+          {!previewMode && (
+            <IconButton size="small" onClick={(e) => { e.stopPropagation(); onDelete(); }}>
+              <DeleteIcon />
+            </IconButton>
+          )}
+        </Box>
+
+        {field.helpText && (
+          <Typography variant="body2" color="textSecondary" style={{ marginBottom: 10 }}>
+            {field.helpText}
+          </Typography>
+        )}
+
+        {renderFieldInput()}
+      </CardContent>
+    </Card>
+  );
+};
+
+// FieldPropertiesPanel component for editing field properties
+const FieldPropertiesPanel = ({ field, onUpdate }) => {
+  const [localField, setLocalField] = useState(field);
+
+  useEffect(() => {
+    setLocalField(field);
+  }, [field]);
+
+  const handleUpdate = (property, value) => {
+    const updatedField = { ...localField, [property]: value };
+    setLocalField(updatedField);
+    onUpdate({ [property]: value });
+  };
+
+  const handleOptionUpdate = (index, value) => {
+    const newOptions = [...localField.options];
+    newOptions[index] = value;
+    handleUpdate('options', newOptions);
+  };
+
+  const addOption = () => {
+    const newOptions = [...localField.options, `Option ${localField.options.length + 1}`];
+    handleUpdate('options', newOptions);
+  };
+
+  const removeOption = (index) => {
+    const newOptions = localField.options.filter((_, i) => i !== index);
+    handleUpdate('options', newOptions);
+  };
+
+  return (
+    <div>
+      <TextField
+        label="Field Label"
+        value={localField.label}
+        onChange={(e) => handleUpdate('label', e.target.value)}
+        fullWidth
+        margin="normal"
+        variant="outlined"
+        style={{ backgroundColor: theme.palette.inputColor }}
+      />
+
+      <TextField
+        label="Field Name"
+        value={localField.name}
+        onChange={(e) => handleUpdate('name', e.target.value)}
+        fullWidth
+        margin="normal"
+        variant="outlined"
+        style={{ backgroundColor: theme.palette.inputColor }}
+      />
+
+      <TextField
+        label="Placeholder"
+        value={localField.placeholder}
+        onChange={(e) => handleUpdate('placeholder', e.target.value)}
+        fullWidth
+        margin="normal"
+        variant="outlined"
+        style={{ backgroundColor: theme.palette.inputColor }}
+      />
+
+      <TextField
+        label="Help Text"
+        value={localField.helpText}
+        onChange={(e) => handleUpdate('helpText', e.target.value)}
+        fullWidth
+        margin="normal"
+        variant="outlined"
+        multiline
+        rows={2}
+        style={{ backgroundColor: theme.palette.inputColor }}
+      />
+
+      <FormControlLabel
+        control={
+          <Switch
+            checked={localField.required}
+            onChange={(e) => handleUpdate('required', e.target.checked)}
+          />
+        }
+        label="Required Field"
+        style={{ marginTop: 10, marginBottom: 10 }}
+      />
+
+      <FormControlLabel
+        control={
+          <Switch
+            checked={localField.visible}
+            onChange={(e) => handleUpdate('visible', e.target.checked)}
+          />
+        }
+        label="Visible"
+        style={{ marginBottom: 10 }}
+      />
+
+      {/* Options for select, radio, checkbox fields */}
+      {(['select', 'multiselect', 'radio', 'checkbox'].includes(localField.type)) && (
+        <div style={{ marginTop: 20 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Options
+          </Typography>
+          {localField.options.map((option, index) => (
+            <Box key={index} display="flex" alignItems="center" marginBottom={1}>
+              <TextField
+                value={option}
+                onChange={(e) => handleOptionUpdate(index, e.target.value)}
+                variant="outlined"
+                size="small"
+                style={{ flex: 1, marginRight: 8, backgroundColor: theme.palette.inputColor }}
+              />
+              <IconButton size="small" onClick={() => removeOption(index)}>
+                <DeleteIcon />
+              </IconButton>
+            </Box>
+          ))}
+          <Button
+            startIcon={<AddIcon />}
+            onClick={addOption}
+            variant="outlined"
+            size="small"
+            style={{ marginTop: 5 }}
+          >
+            Add Option
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FormGenerator;

--- a/frontend/src/views/FormManager.jsx
+++ b/frontend/src/views/FormManager.jsx
@@ -1,0 +1,372 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import {
+  Paper,
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Chip,
+  Box,
+  Grid,
+  Card,
+  CardContent,
+  CardActions,
+  Menu,
+  MenuItem,
+  Tooltip
+} from '@mui/material';
+
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  Visibility as ViewIcon,
+  Share as ShareIcon,
+  MoreVert as MoreIcon,
+  FileCopy as CopyIcon,
+  Assessment as StatsIcon,
+  Link as LinkIcon,
+  Public as PublicIcon,
+  Lock as LockIcon
+} from '@mui/icons-material';
+
+import theme from '../theme.jsx';
+import { Context } from '../context/ContextApi.jsx';
+
+const FormManager = (props) => {
+  const { globalUrl, userdata, isLoggedIn } = props;
+  const { themeMode } = useContext(Context);
+  const navigate = useNavigate();
+
+  const [forms, setForms] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [selectedForm, setSelectedForm] = useState(null);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  useEffect(() => {
+    loadForms();
+  }, []);
+
+  const loadForms = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`${globalUrl}/api/v1/forms`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const formsData = await response.json();
+        setForms(formsData);
+      } else {
+        toast.error('Failed to load forms');
+      }
+    } catch (error) {
+      console.error('Error loading forms:', error);
+      toast.error('Error loading forms');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deleteForm = async (formId) => {
+    try {
+      const response = await fetch(`${globalUrl}/api/v1/forms/${formId}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+
+      if (response.ok) {
+        toast.success('Form deleted successfully');
+        loadForms();
+      } else {
+        toast.error('Failed to delete form');
+      }
+    } catch (error) {
+      console.error('Error deleting form:', error);
+      toast.error('Error deleting form');
+    }
+    setDeleteDialogOpen(false);
+    setSelectedForm(null);
+  };
+
+  const duplicateForm = async (form) => {
+    try {
+      const duplicatedForm = {
+        ...form,
+        id: undefined,
+        name: `${form.name} (Copy)`,
+        metadata: {
+          ...form.metadata,
+          created: null,
+          updated: null,
+          submissions: 0
+        }
+      };
+
+      const response = await fetch(`${globalUrl}/api/v1/forms`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(duplicatedForm),
+      });
+
+      if (response.ok) {
+        toast.success('Form duplicated successfully');
+        loadForms();
+      } else {
+        toast.error('Failed to duplicate form');
+      }
+    } catch (error) {
+      console.error('Error duplicating form:', error);
+      toast.error('Error duplicating form');
+    }
+  };
+
+  const copyFormLink = (formId) => {
+    const formUrl = `${window.location.origin}/forms/${formId}`;
+    navigator.clipboard.writeText(formUrl);
+    toast.success('Form link copied to clipboard');
+  };
+
+  const filteredForms = forms.filter(form =>
+    form.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    form.description.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const handleMenuClick = (event, form) => {
+    setAnchorEl(event.currentTarget);
+    setSelectedForm(form);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setSelectedForm(null);
+  };
+
+  const formatDate = (dateString) => {
+    if (!dateString) return 'Never';
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  const getFormStatusChip = (form) => {
+    if (!form.settings.requireAuth && form.settings.allowAnonymous) {
+      return <Chip icon={<PublicIcon />} label="Public" color="success" size="small" />;
+    } else if (form.settings.requireAuth) {
+      return <Chip icon={<LockIcon />} label="Private" color="warning" size="small" />;
+    }
+    return <Chip label="Internal" color="default" size="small" />;
+  };
+
+  return (
+    <div style={{ padding: 20, backgroundColor: theme.palette.surfaceColor, minHeight: '100vh' }}>
+      {/* Header */}
+      <Paper style={{ padding: 20, marginBottom: 20, backgroundColor: theme.palette.inputColor }}>
+        <Grid container spacing={2} alignItems="center">
+          <Grid item xs>
+            <Typography variant="h4" gutterBottom>
+              Form Manager
+            </Typography>
+            <Typography variant="body1" color="textSecondary">
+              Create and manage your forms
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => navigate('/forms/generator/new')}
+            >
+              Create New Form
+            </Button>
+          </Grid>
+        </Grid>
+
+        <TextField
+          placeholder="Search forms..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          variant="outlined"
+          style={{ marginTop: 15, backgroundColor: theme.palette.inputColor }}
+          fullWidth
+        />
+      </Paper>
+
+      {/* Forms Grid */}
+      <Grid container spacing={3}>
+        {filteredForms.map((form) => (
+          <Grid item xs={12} sm={6} md={4} key={form.id}>
+            <Card style={{ backgroundColor: theme.palette.inputColor, height: '100%' }}>
+              <CardContent>
+                <Box display="flex" justifyContent="space-between" alignItems="flex-start" marginBottom={2}>
+                  <Typography variant="h6" noWrap style={{ flex: 1, marginRight: 10 }}>
+                    {form.name}
+                  </Typography>
+                  <IconButton size="small" onClick={(e) => handleMenuClick(e, form)}>
+                    <MoreIcon />
+                  </IconButton>
+                </Box>
+
+                <Typography variant="body2" color="textSecondary" style={{ marginBottom: 10 }}>
+                  {form.description || 'No description'}
+                </Typography>
+
+                <Box display="flex" justifyContent="space-between" alignItems="center" marginBottom={2}>
+                  {getFormStatusChip(form)}
+                  <Typography variant="caption" color="textSecondary">
+                    {form.fields.length} fields
+                  </Typography>
+                </Box>
+
+                <Typography variant="caption" color="textSecondary" display="block">
+                  Created: {formatDate(form.metadata.created)}
+                </Typography>
+                <Typography variant="caption" color="textSecondary" display="block">
+                  Submissions: {form.metadata.submissions || 0}
+                </Typography>
+              </CardContent>
+
+              <CardActions>
+                <Button
+                  size="small"
+                  startIcon={<ViewIcon />}
+                  onClick={() => window.open(`/forms/${form.id}`, '_blank')}
+                >
+                  View
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<EditIcon />}
+                  onClick={() => navigate(`/forms/generator/${form.id}`)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<LinkIcon />}
+                  onClick={() => copyFormLink(form.id)}
+                >
+                  Copy Link
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+
+      {filteredForms.length === 0 && !loading && (
+        <Paper style={{ padding: 40, textAlign: 'center', backgroundColor: theme.palette.inputColor }}>
+          <Typography variant="h6" gutterBottom>
+            No forms found
+          </Typography>
+          <Typography variant="body1" color="textSecondary" gutterBottom>
+            {searchTerm ? 'Try adjusting your search terms' : 'Create your first form to get started'}
+          </Typography>
+          {!searchTerm && (
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => navigate('/forms/generator/new')}
+              style={{ marginTop: 20 }}
+            >
+              Create New Form
+            </Button>
+          )}
+        </Paper>
+      )}
+
+      {/* Context Menu */}
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={() => { navigate(`/forms/generator/${selectedForm?.id}`); handleMenuClose(); }}>
+          <EditIcon style={{ marginRight: 8 }} />
+          Edit
+        </MenuItem>
+        <MenuItem onClick={() => { duplicateForm(selectedForm); handleMenuClose(); }}>
+          <CopyIcon style={{ marginRight: 8 }} />
+          Duplicate
+        </MenuItem>
+        <MenuItem onClick={() => { copyFormLink(selectedForm?.id); handleMenuClose(); }}>
+          <LinkIcon style={{ marginRight: 8 }} />
+          Copy Link
+        </MenuItem>
+        <MenuItem onClick={() => { setShareDialogOpen(true); handleMenuClose(); }}>
+          <ShareIcon style={{ marginRight: 8 }} />
+          Share
+        </MenuItem>
+        <MenuItem onClick={() => { setDeleteDialogOpen(true); handleMenuClose(); }}>
+          <DeleteIcon style={{ marginRight: 8 }} />
+          Delete
+        </MenuItem>
+      </Menu>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
+        <DialogTitle>Delete Form</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete "{selectedForm?.name}"? This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
+          <Button onClick={() => deleteForm(selectedForm?.id)} color="error">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Share Dialog */}
+      <Dialog open={shareDialogOpen} onClose={() => setShareDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Share Form</DialogTitle>
+        <DialogContent>
+          <Typography gutterBottom>
+            Share this form with others using the link below:
+          </Typography>
+          <TextField
+            fullWidth
+            value={selectedForm ? `${window.location.origin}/forms/${selectedForm.id}` : ''}
+            variant="outlined"
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <IconButton onClick={() => copyFormLink(selectedForm?.id)}>
+                  <CopyIcon />
+                </IconButton>
+              )
+            }}
+            style={{ marginTop: 10, backgroundColor: theme.palette.inputColor }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShareDialogOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default FormManager;


### PR DESCRIPTION
- Add FormGenerator React component with drag-and-drop form builder
- Add FormManager component for managing created forms
- Implement backend API endpoints for form CRUD operations
- Add form data structures and handlers in Go backend
- Support for multiple field types (text, email, select, radio, etc.)
- Form submission handling with workflow trigger integration
- Authentication support for public/private forms
- Add routing for form generator and manager pages

Addresses issue #994 - Web Form Generator feature request