### PR TITLE
fix template error in helm chart

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,0 +1,31 @@
+name: Helm Test
+
+on:
+  push:
+    paths:
+      - "functions/kubernetes/charts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install apt dependencies
+        run: |
+          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+          sudo apt-get install apt-transport-https -y --no-install-recommends
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update
+          sudo apt-get install helm -y --no-install-recommends
+
+      - name: Update helm dependencies
+        run: helm dependency update ./functions/kubernetes/charts/shuffle
+
+      - name: Template helm chart using default values
+        run: helm template shuffle ./functions/kubernetes/charts/shuffle --debug --values ./functions/kubernetes/charts/shuffle/values.yaml

--- a/functions/kubernetes/charts/shuffle/templates/orborus/orborus-cm-env.yaml
+++ b/functions/kubernetes/charts/shuffle/templates/orborus/orborus-cm-env.yaml
@@ -17,7 +17,7 @@ data:
 
   # Shuffle worker configuration
   SHUFFLE_WORKER_IMAGE: {{ include "shuffle.worker.image" . | quote }}
-  SHUFFLE_WORKER_SERVICE_ACCOUNT_NAME: {{ include "shuffle.worker.serviceAccount.name" . | quote  }}"
+  SHUFFLE_WORKER_SERVICE_ACCOUNT_NAME: {{ include "shuffle.worker.serviceAccount.name" . | quote  }}
   {{- if .Values.worker.podSecurityContext.enabled }}
   SHUFFLE_WORKER_POD_SECURITY_CONTEXT: {{ omit .Values.worker.podSecurityContext "enabled" | mustToJson | quote }}
   {{- end }}


### PR DESCRIPTION
https://github.com/Shuffle/Shuffle/pull/1795 introduced a typo, which causes an error when trying to template / install the helm chart. This PR fixes this typo and also introduces a new github workflow, which tests the helm chart by running `helm template`. This returns a non-zero exit code, when there is a template error, e.g.

```
Error: YAML parse error on shuffle/templates/orborus/orborus-cm-env.yaml: error converting YAML to JSON: yaml: line 21: did not find expected key
helm.go:92: 2025-08-27 10:11:03.826258 +0200 CEST m=+0.114790585 [debug] error converting YAML to JSON: yaml: line 21: did not find expected key
YAML parse error on shuffle/templates/orborus/orborus-cm-env.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:152
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:104
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:172
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:316
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:317
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:95
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.9.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.9.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.9.1/command.go:1071
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:91
runtime.main
        runtime/proc.go:285
runtime.goexit
        runtime/asm_arm64.s:1268
```