### PR TITLE
fix apps scaling for k8s shuffle

### DIFF
--- a/functions/onprem/orborus/orborus.go
+++ b/functions/onprem/orborus/orborus.go
@@ -1093,6 +1093,10 @@ func deployK8sWorker(image string, identifier string, env []string) error {
 		env = append(env, fmt.Sprintf("SHUFFLE_LOGS_DISABLED=%s", os.Getenv("SHUFFLE_LOGS_DISABLED")))
 	}
 
+	if len(os.Getenv("SHUFFLE_APP_REPLICAS")) > 0 {
+		env = append(env, fmt.Sprintf("SHUFFLE_APP_REPLICAS=%s", os.Getenv("SHUFFLE_APP_REPLICAS")))
+	}
+
 	clientset, _, err := shuffle.GetKubernetesClient()
 	if err != nil {
 		log.Printf("[ERROR] Error getting kubernetes client:", err)

--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -610,9 +610,9 @@ func deployk8sApp(image string, identifier string, env []string) error {
 
 	// use deployment instead of pod
 	// then expose a service similarly.
-	// number of replicas can be set to os.Getenv("SHUFFLE_SCALE_REPLICAS")
+	// number of replicas can be set to os.Getenv("SHUFFLE_APP_REPLICAS")
 	replicaNumber := 1
-	replicaNumberStr := os.Getenv("SHUFFLE_SCALE_REPLICAS")
+	replicaNumberStr := os.Getenv("SHUFFLE_APP_REPLICAS")
 	if len(replicaNumberStr) > 0 {
 		tmpInt, err := strconv.Atoi(replicaNumberStr)
 		if err != nil {


### PR DESCRIPTION
There is a problem with apps scaling for shuffle in k8s. Using the helm chart, it is not possible to pass environment variables to the worker pods. I have added the ability to pass a variable from orborus to worker to scale applications. I replaced the variable itself with SHUFFLE_APP_REPLICAS, similar to variable for docker (For k8s deployments variable SHUFFLE_SCALE_REPLICAS used both for workers and apps, unlike in docker functions).