### PR TITLE
k8s: remove SHUFFFLE_SWARM_CONFIG env variable from orborus

### DIFF
--- a/functions/kubernetes/charts/shuffle/templates/orborus/orborus-dpl.yaml
+++ b/functions/kubernetes/charts/shuffle/templates/orborus/orborus-dpl.yaml
@@ -86,8 +86,6 @@ spec:
               value: kubernetes
             - name: IS_KUBERNETES
               value: "true"
-            - name: SHUFFLE_SWARM_CONFIG
-              value: run
             {{- if .Values.orborus.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.orborus.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
The env variable was set in the past, due to a bug in orborus logic, but should no longer be required.
In fact, setting this env variable results in app logging not working in k8s, because SHUFFLE_LOGS_DISABLED gets reset to `true` in swarm mode.