### PR TITLE
fix: worker execution takeover for cloud actions

### DIFF
--- a/functions/onprem/worker/worker.go
+++ b/functions/onprem/worker/worker.go
@@ -2652,7 +2652,7 @@ func handleWorkflowQueue(resp http.ResponseWriter, request *http.Request) {
 		}
 	}
 
-	if strings.ToLower(actionResult.Action.Environment) != environment {
+	if strings.ToLower(actionResult.Action.Environment) != environment && len(environment) > 0 {
 		log.Printf("[WARNING] Got an action for %s environment forwarding it to the backend", actionResult.Action.Environment)
 
 		streamUrl := fmt.Sprintf("%s/api/v1/streams", baseUrl)


### PR DESCRIPTION
This bug appears to have existed for quite some time and can be reproduced with the simple workflow shown below.
<img width="681" height="298" alt="screenshot-2026-01-13_12-59-58" src="https://github.com/user-attachments/assets/2cc4765f-7c41-43bd-8678-ddcfa6e781cf" />

In this setup, the subflow runs in a hybrid environment (with wait for result). When the subflow completes, it calls the function responsible for updating the parent workflow
https://github.com/Shuffle/shuffle-shared/blob/main/shared.go#L15402

That function later attempts to send the execution result back to the backend using
https://github.com/Shuffle/shuffle-shared/blob/main/shared.go#L15850

The issue is that this logic does not validate the backendUrl. When the subflow is running on a worker, backendUrl is set to the worker URL, not the actual backend URL. As a result, the worker sends the result back to itself instead of the backend.

This causes the worker to incorrectly take over execution handling that should be processed by the cloud backend, leading to incorrect behavior for hybrid subflows.