### PR TITLE
migrate in-flight executions to live index on startup

### DIFF
--- a/backend/go-app/main.go
+++ b/backend/go-app/main.go
@@ -5308,7 +5308,8 @@ func runInitEs(ctx context.Context) {
 	log.Printf("[INFO] Waiting 30 seconds during init to make sure the opensearch instance is up and running with security features enabled")
 	time.Sleep(30 * time.Second)
 
-	shuffle.InitOpensearchIndexes()
+	shuffle.InitOpensearchIndices()
+	shuffle.StartExecutionLifecycleJobs(ctx)
 
 	// FIXME: This should ONLY run on one backend instance. This may cause interference.
 	schedules, err := shuffle.GetAllSchedules(ctx, "ALL")

--- a/backend/go-app/test-suite/integration_main.go
+++ b/backend/go-app/test-suite/integration_main.go
@@ -118,7 +118,7 @@ func initializeIntegrationBackends(t *testing.T) {
 			0,
 		)
 
-		shuffle.InitOpensearchIndexes()
+		shuffle.InitOpensearchIndices()
 	})
 	if initializeErr != nil {
 		t.Fatalf("initialize Shuffle integration backends: %v", initializeErr)
@@ -139,12 +139,12 @@ func TestOpensearchInit(t *testing.T) {
 		t.Fatal("OpenSearch client was not initialized")
 	}
 
-	baseIndexes := shuffle.GetOpensearchBaseIndexes()
-	if len(baseIndexes) == 0 {
-		t.Fatal("Shuffle returned no base OpenSearch indexes")
+	baseIndices := shuffle.GetOpensearchBaseIndices()
+	if len(baseIndices) == 0 {
+		t.Fatal("Shuffle returned no base OpenSearch indices")
 	}
-	expectedAliases := make([]string, 0, len(baseIndexes))
-	for _, baseIndex := range baseIndexes {
+	expectedAliases := make([]string, 0, len(baseIndices))
+	for _, baseIndex := range baseIndices {
 		expectedAliases = append(expectedAliases, shuffle.GetESIndexPrefix(baseIndex))
 	}
 
@@ -585,7 +585,7 @@ func TestDatastoreIntegration(t *testing.T) {
 	testRunID := uuid.NewV4().String()
 	category := "integration_large_" + strings.ReplaceAll(testRunID, "-", "")
 	keyPrefix := "integration-bulk-" + testRunID
-	// The current OpenSearch mapping indexes Value as one term, whose hard limit
+	// The current OpenSearch mapping indices Value as one term, whose hard limit
 	// is 32,766 bytes. Exercise close to that boundary without exceeding it.
 	// FIX IT PLEASE
 	largeEntries := make([]string, 1500)

--- a/functions/kubernetes/charts/shuffle/README.md
+++ b/functions/kubernetes/charts/shuffle/README.md
@@ -213,6 +213,32 @@ Alternatively, you can disable the built-in OpenSearch installation using `opens
 Provide your own OpenSearch url and username with `backend.openSearch.url` and `backend.openSearch.username`.
 The password should be provided with the `SHUFFLE_OPENSEARCH_PASSWORD` env variable to the backend.
 
+### Index management and the `workflowexecution` hot/cold split
+
+The backend automatically manages OpenSearch index/mapping/ISM rollover policies on startup
+(`InitOpensearchIndices`), and runs background jobs that keep the high-volume
+`workflowexecution` index split into a small "live" index (in-flight + recently-finished
+executions) and a rolling, retention-managed "archive" index (everything else). None of this
+requires any Helm chart changes to enable — it is controlled entirely through backend
+environment variables, which you can set via `backend.extraEnvVars` (see the
+`@param backend.extraEnvVars` example in `values.yaml`) or `backend.extraEnvVarsCM` /
+`backend.extraEnvVarsSecret`:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `SHUFFLE_SKIP_OPENSEARCH_INDEX_INIT` | unset (runs) | Fully disables Shuffle's OpenSearch index/mapping/ISM management. Set to `true` only if you provision and manage all Shuffle OpenSearch indexes, mappings, and ISM policies yourself (e.g. via your own Terraform/IaC). |
+| `SHUFFLE_SKIP_EXECUTION_LIVE_MIGRATION` | unset (runs) | Skips only the one-time startup migration of pre-upgrade in-flight executions into the new live index. Safe to disable on very large deployments that want to run this manually during a maintenance window instead of automatically on every restart. |
+| `SHUFFLE_SKIP_EXECUTION_ARCHIVAL_SWEEP` | unset (runs) | Skips only the recurring sweep that moves finished executions from the live index to the archive. Disabling this defeats the point of the hot/cold split (the live index grows unbounded) — only disable if you have your own equivalent process. |
+| `OPENSEARCH_EXECUTION_GRACE_PERIOD` | `1h` | How long a finished execution stays in the live index before it becomes eligible for archival. |
+| `OPENSEARCH_EXECUTION_ARCHIVE_SWEEP_INTERVAL` | `30m` | How often the archival sweep runs. |
+| `OPENSEARCH_INDEX_RETENTION_DAYS` | unset (code default: `workflowexecution` = `365` days) | Per-index ISM retention override, e.g. `{"workflowexecution": 180}`. Same mechanism used for `shuffle_logs`. The 365-day default for `workflowexecution` is a built-in code default (`getOpensearchRetentionDays`), not an env var default — this JSON var only needs to be set to override it. |
+| `OPENSEARCH_NOTIFICATION_RETENTION_DAYS` | `0` (disabled) | Opt-in only: deletes read/ignored notifications older than this many days. Notifications are kept forever unless you explicitly set this. |
+
+`SHUFFLE_SKIP_OPENSEARCH_INDEX_INIT` only affects index/mapping/ISM *infrastructure*
+management — it does **not** disable the migration/sweep jobs above, which run independently so
+that self-managed-infrastructure deployments still get the scaling benefit of the hot/cold
+split.
+
 ## Parameters
 
 #### Global parameters


### PR DESCRIPTION
Start opensearch index hygiene background jobs and document new env variables. Details are available in https://github.com/Shuffle/shuffle-shared/pull/455.

Updated docs: https://github.com/Shuffle/shuffle-docs/pull/236

Requires https://github.com/Shuffle/shuffle-shared/pull/455 to be merged and a new shuffle-shared release to be drafted before merge. This PR needs to be updated to the latest shuffle-shared version.