### PR TITLE
fix page crash on empty datastore categories

### DIFF
--- a/frontend/src/components/CacheView.jsx
+++ b/frontend/src/components/CacheView.jsx
@@ -418,12 +418,13 @@ const CacheView = memo((props) => {
 		.then((responseJson) => {
             setCachedLoaded(true);
 			if (responseJson?.success === true) {
-				setListCache(responseJson.keys);
+				const responseKeys = responseJson.keys || [];
+				setListCache(responseKeys);
 
 				if (responseJson.total_amount !== undefined && responseJson.total_amount !== null && responseJson.total_amount > 0) {
 					setTotalAmount(responseJson.total_amount)
 				} else {
-					setTotalAmount(responseJson.keys.length)
+					setTotalAmount(responseKeys.length)
 				}
 
 				if (responseJson?.cursor !== undefined && responseJson?.cursor !== null && responseJson?.cursor !== "") {
@@ -598,7 +599,7 @@ const CacheView = memo((props) => {
 
 		}
 
-        if (listCache.length > 0) {
+        if (listCache?.length > 0) {
             const selectedCache = listCache.find((data) => data.key === dataValue.key);
             if (selectedCache?.suborg_distribution?.length > 0) {
                 entry.suborg_distribution = selectedCache.suborg_distribution;
@@ -2734,7 +2735,7 @@ const CacheView = memo((props) => {
             />}
 
 		      <DataGrid
-				rows={listCache}
+				rows={listCache || []}
 				columns={columns}
 				checkboxSelection
 				disableRowSelectionOnClick
@@ -2751,7 +2752,7 @@ const CacheView = memo((props) => {
 				autoHeight={true}
 				sx={{
 					marginTop: 1, 
-					height: listCache.length*52+500,
+					height: (listCache?.length || 0)*52+500,
 					width: "100%",
 					'.MuiTablePagination-selectLabel, .MuiTablePagination-select, .MuiTablePagination-selectIcon': {
 					  display: 'none',
@@ -2881,7 +2882,7 @@ const CacheView = memo((props) => {
 								// selectedRows holds DataGrid row ids (getRowId = key_category),
 								// not the raw key. Resolve each back to its item before deleting.
 								for (var key in selectedRows) {
-									const item = listCache.find(it => encodeURIComponent(`${it.key}_${it.category || ""}`) === selectedRows[key])
+									const item = listCache?.find(it => encodeURIComponent(`${it.key}_${it.category || ""}`) === selectedRows[key])
 									if (!item) continue
 									deleteEntry(orgId, item.key, item.category, false)
 								}

--- a/frontend/src/components/CacheView.jsx
+++ b/frontend/src/components/CacheView.jsx
@@ -507,6 +507,11 @@ const CacheView = memo((props) => {
 					if (responseJson?.category_config?.automations !== undefined && responseJson?.category_config?.automations !== null && responseJson?.category_config?.automations.length > 0) {
 						// Find icons if they exist
 						for (var key in responseJson.category_config.automations) {
+							// Options may be null if an automation was stored without any (no omitempty on the backend field)
+							if (!Array.isArray(responseJson.category_config.automations[key].options)) {
+								responseJson.category_config.automations[key].options = []
+							}
+
 							//if (responseJson.category_config.automations[key].icon === undefined || responseJson.category_config.automations[key].icon === null || responseJson.category_config.automations[key].icon === "") {
 							const foundItem = defaultAutomation.find((automation) => automation.name === responseJson.category_config.automations[key].name)
 							if (foundItem) {
@@ -1171,7 +1176,7 @@ const CacheView = memo((props) => {
 								style={{ marginRight: 10, marginTop: -10, }}
 								checked={automation.enabled}
 								// Check if automation options have a value
-								disabled={automation.name !== "Enrich" && automation.name != "Run AI Agent" && (automation?.disabled === true || automation.options.length === 0 || automation.options.some((option) => option.value === ""))}
+								disabled={automation.name !== "Enrich" && automation.name != "Run AI Agent" && (automation?.disabled === true || (automation?.options || []).length === 0 || (automation?.options || []).some((option) => option.value === ""))}
 								onChange={(e) => {
 									e.stopPropagation()
 									e.preventDefault()


### PR DESCRIPTION
This should resolve a page crash when trying to load a datastore category
without any keys.
The page would just turn white with the following error in the browser console:


```
index-B9_xOdtZ.js:40 TypeError: Cannot read properties of undefined (reading 'length')
    at index-B9_xOdtZ.js:5548:151257
    at wne (index-B9_xOdtZ.js:38:17091)
    at zQ (index-B9_xOdtZ.js:40:3159)
    at cTe (index-B9_xOdtZ.js:40:2369)
    at jTe (index-B9_xOdtZ.js:40:47651)
    at TTe (index-B9_xOdtZ.js:40:40005)
    at KGe (index-B9_xOdtZ.js:40:39928)
    at XF (index-B9_xOdtZ.js:40:39776)
    at JQ (index-B9_xOdtZ.js:40:36109)
    at STe (index-B9_xOdtZ.js:40:35054)
WQ @ index-B9_xOdtZ.js:40
n.callback @ index-B9_xOdtZ.js:40
Yue @ index-B9_xOdtZ.js:38
dde @ index-B9_xOdtZ.js:40
CTe @ index-B9_xOdtZ.js:40
VGe @ index-B9_xOdtZ.js:40
QGe @ index-B9_xOdtZ.js:40
eC @ index-B9_xOdtZ.js:40
STe @ index-B9_xOdtZ.js:40
_ @ index-B9_xOdtZ.js:25
E @ index-B9_xOdtZ.js:25
postMessage
I @ index-B9_xOdtZ.js:25
L @ index-B9_xOdtZ.js:25
e.unstable_scheduleCallback @ index-B9_xOdtZ.js:25
OTe @ index-B9_xOdtZ.js:40
zh @ index-B9_xOdtZ.js:40
$m @ index-B9_xOdtZ.js:40
RGe @ index-B9_xOdtZ.js:38
(anonymous) @ index-B9_xOdtZ.js:5548
Promise.then
rn @ index-B9_xOdtZ.js:5548
onClick @ index-B9_xOdtZ.js:5548
gVe @ index-B9_xOdtZ.js:37
vVe @ index-B9_xOdtZ.js:37
yVe @ index-B9_xOdtZ.js:37
Fue @ index-B9_xOdtZ.js:37
jke @ index-B9_xOdtZ.js:37
(anonymous) @ index-B9_xOdtZ.js:37
jne @ index-B9_xOdtZ.js:40
J2e @ index-B9_xOdtZ.js:37
SU @ index-B9_xOdtZ.js:37
rne @ index-B9_xOdtZ.js:37
MVe @ index-B9_xOdtZ.js:37
```
